### PR TITLE
Squash of:

### DIFF
--- a/iamf/BUILD
+++ b/iamf/BUILD
@@ -6,6 +6,7 @@ cc_library(
     hdrs = ["aac_decoder_config.h"],
     deps = [
         ":ia",
+        ":obu_util",
         ":write_bit_buffer",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
@@ -103,6 +104,7 @@ cc_library(
     hdrs = ["flac_decoder_config.h"],
     deps = [
         ":ia",
+        ":obu_util",
         ":write_bit_buffer",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
@@ -123,6 +125,7 @@ cc_library(
         ":ia",
         ":obu_base",
         ":obu_header",
+        ":obu_util",
         ":write_bit_buffer",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
@@ -199,7 +202,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -209,6 +212,7 @@ cc_library(
     hdrs = ["opus_decoder_config.h"],
     deps = [
         ":ia",
+        ":obu_util",
         ":write_bit_buffer",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
@@ -268,6 +272,17 @@ cc_library(
         ":ia",
         "//iamf/cli:leb_generator",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "read_bit_buffer",
+    srcs = ["read_bit_buffer.cc"],
+    hdrs = ["read_bit_buffer.h"],
+    deps = [
+        "//iamf/cli:leb_generator",
         "@com_google_absl//absl/status",
     ],
 )

--- a/iamf/aac_decoder_config.cc
+++ b/iamf/aac_decoder_config.cc
@@ -18,6 +18,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "iamf/ia.h"
+#include "iamf/obu_util.h"
 #include "iamf/write_bit_buffer.h"
 #include "libSYS/include/machine_type.h"
 
@@ -26,59 +27,42 @@ namespace iamf_tools {
 namespace {
 // Validates the `AacDecoderConfig`.
 absl::Status ValidatePayload(const AacDecoderConfig& decoder_config) {
-  if (decoder_config.decoder_config_descriptor_tag_ != 0x04) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid decoder_config_descriptor_tag= ",
-                     decoder_config.decoder_config_descriptor_tag_));
-  }
+  RETURN_IF_NOT_OK(ValidateEqual(decoder_config.decoder_config_descriptor_tag_,
+                                 AacDecoderConfig::kDecoderConfigDescriptorTag,
+                                 "decoder_config_descriptor_tag"));
   // IAMF restricts several fields.
-  if (decoder_config.object_type_indication_ != 0x40) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid object_type_indication= ",
-                     decoder_config.object_type_indication_));
-  }
-  if (decoder_config.stream_type_ != 0x05) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid stream_type= ", decoder_config.stream_type_));
-  }
-  if (decoder_config.upstream_ != 0) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid upstream= ", decoder_config.upstream_));
-  }
-  if (decoder_config.decoder_specific_info_.decoder_specific_info_tag != 0x05) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Invalid decoder_specific_info_tag= ",
-        decoder_config.decoder_specific_info_.decoder_specific_info_tag));
-  }
+  RETURN_IF_NOT_OK(ValidateEqual(decoder_config.object_type_indication_,
+                                 AacDecoderConfig::kObjectTypeIndication,
+                                 "object_type_indication"));
+  RETURN_IF_NOT_OK(ValidateEqual(decoder_config.stream_type_,
+                                 AacDecoderConfig::kStreamType, "stream_type"));
+  RETURN_IF_NOT_OK(ValidateEqual(decoder_config.upstream_,
+                                 AacDecoderConfig::kUpstream, "upstream"));
+  RETURN_IF_NOT_OK(ValidateEqual(
+      decoder_config.decoder_specific_info_.decoder_specific_info_tag,
+      AacDecoderConfig::DecoderSpecificInfo::kDecoderSpecificInfoTag,
+      "decoder_specific_info_tag"));
 
   const AudioSpecificConfig& audio_specific_config =
       decoder_config.decoder_specific_info_.audio_specific_config;
 
-  if (audio_specific_config.audio_object_type_ != 2) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid audio_object_type= ",
-                     audio_specific_config.audio_object_type_));
-  }
-  if (audio_specific_config.channel_configuration_ != 2) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid channel_configuration= ",
-                     audio_specific_config.channel_configuration_));
-  }
-  if (audio_specific_config.ga_specific_config_.frame_length_flag != 0) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Invalid frame_length_flag= ",
-        audio_specific_config.ga_specific_config_.frame_length_flag));
-  }
-  if (audio_specific_config.ga_specific_config_.depends_on_core_coder != 0) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Invalid depends_on_core_coder= ",
-        audio_specific_config.ga_specific_config_.depends_on_core_coder));
-  }
-  if (audio_specific_config.ga_specific_config_.extension_flag != 0) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid extension_flag= ",
-                     audio_specific_config.ga_specific_config_.extension_flag));
-  }
+  RETURN_IF_NOT_OK(ValidateEqual(audio_specific_config.audio_object_type_,
+                                 AudioSpecificConfig::kAudioObjectType,
+                                 "audio_object_type"));
+  RETURN_IF_NOT_OK(ValidateEqual(audio_specific_config.channel_configuration_,
+                                 AudioSpecificConfig::kChannelConfiguration,
+                                 "channel_configuration"));
+  RETURN_IF_NOT_OK(
+      ValidateEqual(audio_specific_config.ga_specific_config_.frame_length_flag,
+                    AudioSpecificConfig::GaSpecificConfig::kFrameLengthFlag,
+                    "frame_length_flag"));
+  RETURN_IF_NOT_OK(ValidateEqual(
+      audio_specific_config.ga_specific_config_.depends_on_core_coder,
+      AudioSpecificConfig::GaSpecificConfig::kDependsOnCoreCoder,
+      "depends_on_core_coder"));
+  RETURN_IF_NOT_OK(ValidateEqual(
+      audio_specific_config.ga_specific_config_.extension_flag,
+      AudioSpecificConfig::GaSpecificConfig::kExtensionFlag, "extension_flag"));
   return absl::OkStatus();
 }
 

--- a/iamf/aac_decoder_config.h
+++ b/iamf/aac_decoder_config.h
@@ -45,6 +45,9 @@ class AudioSpecificConfig {
     kSampleFrequencyIndexEscapeValue = 15
   };
 
+  static constexpr uint8_t kAudioObjectType = 2;
+  static constexpr uint8_t kChannelConfiguration = 2;
+
   friend bool operator==(const AudioSpecificConfig& lhs,
                          const AudioSpecificConfig& rhs) = default;
 
@@ -59,29 +62,38 @@ class AudioSpecificConfig {
    */
   void Print() const;
 
-  uint8_t audio_object_type_;                    // 5 bits.
-  SampleFrequencyIndex sample_frequency_index_;  // 4 bits.
+  uint8_t audio_object_type_ = kAudioObjectType;  // 5 bits.
+  SampleFrequencyIndex sample_frequency_index_;   // 4 bits.
   // if(sample_frequency_index == kSampleFrequencyIndexEscapeValue) {
   uint32_t sampling_frequency_ = 0;  // 24 bits.
   // }
-  uint8_t channel_configuration_;  // 4 bits.
+  uint8_t channel_configuration_ = kChannelConfiguration;  // 4 bits.
 
   // The ISO spec allows several different types of configs to follow depending
   // on `audio_object_type`. Valid IAMF streams always use the general audio
   // specific config because of the fixed `audio_object_type == 2`.
   struct GaSpecificConfig {
+    static constexpr bool kFrameLengthFlag = false;
+    static constexpr bool kDependsOnCoreCoder = false;
+    static constexpr bool kExtensionFlag = false;
+
     friend bool operator==(const GaSpecificConfig& lhs,
                            const GaSpecificConfig& rhs) = default;
 
-    bool frame_length_flag;
-    bool depends_on_core_coder;
-    bool extension_flag;
+    bool frame_length_flag = kFrameLengthFlag;
+    bool depends_on_core_coder = kDependsOnCoreCoder;
+    bool extension_flag = kExtensionFlag;
   } ga_specific_config_;
 };
 
 /*!\brief The `CodecConfig` `decoder_config` field for AAC. */
 class AacDecoderConfig {
  public:
+  static constexpr uint8_t kDecoderConfigDescriptorTag = 0x04;
+  static constexpr uint8_t kObjectTypeIndication = 0x40;
+  static constexpr uint8_t kStreamType = 0x05;
+  static constexpr bool kUpstream = false;
+
   friend bool operator==(const AacDecoderConfig& lhs,
                          const AacDecoderConfig& rhs) = default;
 
@@ -118,19 +130,21 @@ class AacDecoderConfig {
    */
   void Print() const;
 
-  uint8_t decoder_config_descriptor_tag_;
-  uint8_t object_type_indication_;
-  uint8_t stream_type_;  // 6 bits.
-  bool upstream_;
+  uint8_t decoder_config_descriptor_tag_ = kDecoderConfigDescriptorTag;
+  uint8_t object_type_indication_ = kObjectTypeIndication;
+  uint8_t stream_type_ = kStreamType;  // 6 bits.
+  bool upstream_ = kUpstream;
   bool reserved_;
   uint32_t buffer_size_db_;  // 24 bits.
   uint32_t max_bitrate_;
   uint32_t average_bit_rate_;
 
   struct DecoderSpecificInfo {
+    static constexpr uint8_t kDecoderSpecificInfoTag = 0x05;
+
     friend bool operator==(const DecoderSpecificInfo& lhs,
                            const DecoderSpecificInfo& rhs) = default;
-    uint8_t decoder_specific_info_tag;
+    uint8_t decoder_specific_info_tag = kDecoderSpecificInfoTag;
     AudioSpecificConfig audio_specific_config;
   } decoder_specific_info_;
   // ProfileLevelIndicationIndexDescriptor is an extension in the original

--- a/iamf/audio_element.h
+++ b/iamf/audio_element.h
@@ -223,7 +223,7 @@ class AudioElementObu : public ObuBase {
   AudioElementObu(AudioElementObu&& other) = default;
 
   /*!\brief Destructor. */
-  ~AudioElementObu() override {}
+  ~AudioElementObu() override = default;
 
   friend bool operator==(const AudioElementObu& lhs,
                          const AudioElementObu& rhs) = default;

--- a/iamf/cli/BUILD
+++ b/iamf/cli/BUILD
@@ -279,6 +279,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -333,6 +334,7 @@ cc_library(
         "//iamf/cli/proto:ia_sequence_header_cc_proto",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -570,6 +572,24 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_audio_to_tactile//:dsp",
+    ],
+)
+
+cc_library(
+    name = "wav_sample_provider",
+    srcs = ["wav_sample_provider.cc"],
+    hdrs = ["wav_sample_provider.h"],
+    deps = [
+        ":audio_element_with_data",
+        ":demixing_module",
+        ":wav_reader",
+        "//iamf:ia",
+        "//iamf/cli/proto:audio_frame_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/iamf/cli/aac_encoder_decoder.h
+++ b/iamf/cli/aac_encoder_decoder.h
@@ -9,8 +9,8 @@
  * source code in the PATENTS file, you can obtain it at
  * www.aomedia.org/license/patent.
  */
-#ifndef CLI_AAC_DECODER_ENCODER_H_
-#define CLI_AAC_DECODER_ENCODER_H_
+#ifndef CLI_AAC_ENCODER_DECODER_H_
+#define CLI_AAC_ENCODER_DECODER_H_
 
 #include <cstdint>
 #include <memory>
@@ -120,4 +120,4 @@ class AacEncoder : public EncoderBase {
 
 }  // namespace iamf_tools
 
-#endif  // CLI_AAC_DECODER_ENCODER_H_
+#endif  // CLI_AAC_ENCODER_DECODER_H_

--- a/iamf/cli/arbitrary_obu_generator.cc
+++ b/iamf/cli/arbitrary_obu_generator.cc
@@ -101,9 +101,9 @@ absl::Status ArbitraryObuGenerator::Generate(
         insertion_hook = kInsertionHookAfterIaSequenceHeader;
         break;
       default:
-        LOG(ERROR) << "Unknown insertion hook: "
-                   << arbitrary_obu_metadata.insertion_hook();
-        return absl::InvalidArgumentError("");
+        return absl::InvalidArgumentError(
+            absl::StrCat("Unknown insertion hook= ",
+                         arbitrary_obu_metadata.insertion_hook()));
     }
 
     std::vector<uint8_t> payload(arbitrary_obu_metadata.payload().size());

--- a/iamf/cli/flac_encoder_decoder.h
+++ b/iamf/cli/flac_encoder_decoder.h
@@ -9,8 +9,8 @@
  * source code in the PATENTS file, you can obtain it at
  * www.aomedia.org/license/patent.
  */
-#ifndef CLI_FLAC_DECODER_ENCODER_H_
-#define CLI_FLAC_DECODER_ENCODER_H_
+#ifndef CLI_FLAC_ENCODER_DECODER_H_
+#define CLI_FLAC_ENCODER_DECODER_H_
 
 #include <cstddef>
 #include <cstdint>
@@ -148,4 +148,4 @@ class FlacEncoder : public EncoderBase {
 
 }  // namespace iamf_tools
 
-#endif  // CLI_FLAC_DECODER_ENCODER_H_
+#endif  // CLI_FLAC_ENCODER_DECODER_H_

--- a/iamf/cli/ia_sequence_header_generator.cc
+++ b/iamf/cli/ia_sequence_header_generator.cc
@@ -15,6 +15,7 @@
 
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "iamf/cli/cli_util.h"
 #include "iamf/cli/proto/ia_sequence_header.pb.h"
 #include "iamf/ia.h"
@@ -35,8 +36,8 @@ absl::Status CopyProfileVersion(
       obu_profile_version = ProfileVersion::kIamfBaseProfile;
       return absl::OkStatus();
     default:
-      LOG(ERROR) << "Unknown profile version: " << metadata_profile_version;
-      return absl::InvalidArgumentError("");
+      return absl::InvalidArgumentError(
+          absl::StrCat("Unknown profile version= ", metadata_profile_version));
   }
 }
 

--- a/iamf/cli/iamf_components.cc
+++ b/iamf/cli/iamf_components.cc
@@ -11,8 +11,10 @@
  */
 #include "iamf/cli/iamf_components.h"
 
+#include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -31,7 +33,8 @@ std::unique_ptr<MixPresentationFinalizerBase> CreateMixPresentationFinalizer(
     const ::google::protobuf::RepeatedPtrField<
         iamf_tools_cli_proto::MixPresentationObuMetadata>&
         mix_presentation_metadata,
-    const std::string& /*file_name_prefix*/) {
+    const std::string& /*file_name_prefix*/,
+    std::optional<uint8_t> /*output_wav_file_bit_depth_override*/) {
   return std::make_unique<DummyMixPresentationFinalizer>(
       mix_presentation_metadata);
 }

--- a/iamf/cli/iamf_components.h
+++ b/iamf/cli/iamf_components.h
@@ -13,7 +13,9 @@
 #ifndef CLI_IAMF_COMPONENTS_H_
 #define CLI_IAMF_COMPONENTS_H_
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -31,13 +33,16 @@ namespace iamf_tools {
  *
  * \param mix_presentation_metadata Input mix presentation metadata.
  * \param file_name_prefix Prefix of output file name.
+ * \param output_wav_file_bit_depth_override Override for the bit-depth of
+ *     the rendered wav file.
  * \return Unique pointer to the created Mix Presentation finalizer.
  */
 std::unique_ptr<MixPresentationFinalizerBase> CreateMixPresentationFinalizer(
     const ::google::protobuf::RepeatedPtrField<
         iamf_tools_cli_proto::MixPresentationObuMetadata>&
         mix_presentation_metadata,
-    const std::string& file_name_prefix);
+    const std::string& file_name_prefix,
+    std::optional<uint8_t> output_wav_file_bit_depth_override);
 
 /*\!brief Creates instances of `ObuSequencerBase`.
  *

--- a/iamf/cli/mix_presentation_generator.cc
+++ b/iamf/cli/mix_presentation_generator.cc
@@ -98,9 +98,9 @@ absl::Status FillRenderingConfig(
           kHeadphonesRenderingModeBinaural;
       break;
     default:
-      LOG(ERROR) << "Invalid headphones rendering mode: "
-                 << input_rendering_config.headphones_rendering_mode();
-      return absl::InvalidArgumentError("");
+      return absl::InvalidArgumentError(
+          absl::StrCat("Unknown headphones_rendering_mode= ",
+                       input_rendering_config.headphones_rendering_mode()));
   }
 
   RETURN_IF_NOT_OK(Uint32ToUint8(input_rendering_config.reserved(),
@@ -182,10 +182,11 @@ absl::Status FillLayouts(
   sub_mix.num_layouts = input_sub_mix.num_layouts();
 
   if (input_sub_mix.layouts().size() != input_sub_mix.num_layouts()) {
-    LOG(ERROR) << "Expected " << input_sub_mix.num_layouts()
-               << " layouts in the Mix Presentation OBU user input. Found "
-               << input_sub_mix.layouts().size();
-    return absl::InvalidArgumentError("");
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Inconsistent number of layouts in user input. "
+        "input_sub_mix.num_layouts()= ",
+        input_sub_mix.num_layouts(), " vs  input_sub_mix.layouts().size()= ",
+        input_sub_mix.layouts().size()));
   }
 
   // Reserve the layouts vector and copy in the layouts.
@@ -230,9 +231,8 @@ absl::Status FillLayouts(
         break;
       }
       default:
-        LOG(ERROR) << "Invalid layout type: "
-                   << input_loudness_layout.layout_type();
-        return absl::InvalidArgumentError("");
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Unknown layout_type= ", input_loudness_layout.layout_type()));
     }
 
     RETURN_IF_NOT_OK(MixPresentationGenerator::CopyInfoType(

--- a/iamf/cli/proto/codec_config.proto
+++ b/iamf/cli/proto/codec_config.proto
@@ -44,11 +44,11 @@ message OpusEncoderMetadata {
 
 message OpusDecoderConfig {
   optional uint32 version = 1;
-  optional uint32 output_channel_count = 2;
+  optional uint32 output_channel_count = 2 [default = 2];
   optional uint32 pre_skip = 3;
   optional uint32 input_sample_rate = 4;
-  optional int32 output_gain = 5;
-  optional uint32 mapping_family = 6;
+  optional int32 output_gain = 5 [default = 0];
+  optional uint32 mapping_family = 6 [default = 0];
   optional OpusEncoderMetadata opus_encoder_metadata = 7;
 }
 
@@ -81,23 +81,23 @@ message AacEncoderMetadata {
 
 message AacDecoderSpecificInfo {
   optional uint32 decoder_specific_info_descriptor_tag = 5 [default = 0x05];
-  optional uint32 audio_object_type = 1;
+  optional uint32 audio_object_type = 1 [default = 2];
   optional SampleFrequencyIndex sample_frequency_index = 2;
   optional uint32 sampling_frequency = 3;
-  optional uint32 channel_configuration = 4;
+  optional uint32 channel_configuration = 4 [default = 2];
 }
 
 message AacGaSpecificConfig {
-  optional bool frame_length_flag = 1;
-  optional bool depends_on_core_coder = 2;
-  optional bool extension_flag = 3;
+  optional bool frame_length_flag = 1 [default = false];
+  optional bool depends_on_core_coder = 2 [default = false];
+  optional bool extension_flag = 3 [default = false];
 }
 
 message AacDecoderConfig {
   optional uint32 decoder_config_descriptor_tag = 11 [default = 0x04];
-  optional uint32 object_type_indication = 1;
-  optional uint32 stream_type = 2;
-  optional bool upstream = 3;
+  optional uint32 object_type_indication = 1 [default = 0x40];
+  optional uint32 stream_type = 2 [default = 5];
+  optional bool upstream = 3 [default = false];
   optional bool reserved = 4;
   optional uint32 buffer_size_db = 5;
   optional uint32 max_bitrate = 6;
@@ -127,13 +127,15 @@ message FlacMetaBlockHeader {
 message FlacMetaBlockStreamInfo {
   optional uint32 minimum_block_size = 1;
   optional uint32 maximum_block_size = 2;
-  optional uint32 minimum_frame_size = 3;
-  optional uint32 maximum_frame_size = 4;
+  optional uint32 minimum_frame_size = 3 [default = 0];
+  optional uint32 maximum_frame_size = 4 [default = 0];
   optional uint32 sample_rate = 5;
-  optional uint32 number_of_channels = 6;
+  optional uint32 number_of_channels = 6 [default = 1];
   optional uint32 bits_per_sample = 7;
   optional uint64 total_samples_in_stream = 8;
-  optional bytes md5_signature = 9;
+  optional bytes md5_signature = 9
+      [default =
+           "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"];
 }
 
 // Settings to configure `libflac`.

--- a/iamf/cli/proto/ia_sequence_header.proto
+++ b/iamf/cli/proto/ia_sequence_header.proto
@@ -21,7 +21,7 @@ enum ProfileVerson {
 }
 
 message IASequenceHeaderObuMetadata {
-  optional uint32 ia_code = 1;
+  optional uint32 ia_code = 1 [default = 0x69616d66 /* "iamf" */];
   optional ProfileVerson primary_profile = 2;
   optional ProfileVerson additional_profile = 3;
   optional ObuHeaderMetadata obu_header = 4;

--- a/iamf/cli/proto/test_vector_metadata.proto
+++ b/iamf/cli/proto/test_vector_metadata.proto
@@ -39,6 +39,9 @@ message TestVectorMetadata {
   optional string base_test = 7;
   optional int32 ms_per_fragment = 8 [default = 10000];
   optional bool override_computed_recon_gains = 9 [default = false];
+  // An override to control the output bit-depth of the output `rendered` wav
+  // file.
+  optional uint32 output_wav_file_bit_depth_override = 12;
 
   // `true` partitions the input mix gain parameter blocks to be aligned with
   // single frames. The `param_definition` in the descriptor OBUs must be

--- a/iamf/cli/testdata/test_000000_3.textproto
+++ b/iamf/cli/testdata/test_000000_3.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000002.textproto
+++ b/iamf/cli/testdata/test_000002.textproto
@@ -37,7 +37,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000003.textproto
+++ b/iamf/cli/testdata/test_000003.textproto
@@ -37,7 +37,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000005.textproto
+++ b/iamf/cli/testdata/test_000005.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000006.textproto
+++ b/iamf/cli/testdata/test_000006.textproto
@@ -30,7 +30,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000012.textproto
+++ b/iamf/cli/testdata/test_000012.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000014.textproto
+++ b/iamf/cli/testdata/test_000014.textproto
@@ -23,10 +23,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000005"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -39,11 +39,8 @@ codec_config_metadata {
     audio_roll_distance: -32
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 0
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000015.textproto
+++ b/iamf/cli/testdata/test_000015.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000016.textproto
+++ b/iamf/cli/testdata/test_000016.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000017.textproto
+++ b/iamf/cli/testdata/test_000017.textproto
@@ -26,7 +26,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000018.textproto
+++ b/iamf/cli/testdata/test_000018.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000019.textproto
+++ b/iamf/cli/testdata/test_000019.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000020.textproto
+++ b/iamf/cli/testdata/test_000020.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "6.2.2/roll"
   ]
   base_test: "test_000014"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000021.textproto
+++ b/iamf/cli/testdata/test_000021.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "3.11.1/num_samples_per_frame"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -2
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000022.textproto
+++ b/iamf/cli/testdata/test_000022.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "3.11.1/num_samples_per_frame"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -5
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000023.textproto
+++ b/iamf/cli/testdata/test_000023.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "3.11.1/num_samples_per_frame"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -16
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000024.textproto
+++ b/iamf/cli/testdata/test_000024.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "3.11.1/num_samples_per_frame"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -2
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000025.textproto
+++ b/iamf/cli/testdata/test_000025.textproto
@@ -23,10 +23,10 @@ test_vector_metadata {
     "3.11.1/version"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -39,11 +39,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 16
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000026.textproto
+++ b/iamf/cli/testdata/test_000026.textproto
@@ -23,10 +23,10 @@ test_vector_metadata {
     "3.11.1/output_channel_count"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,8 +42,6 @@ codec_config_metadata {
       output_channel_count: 1
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000027.textproto
+++ b/iamf/cli/testdata/test_000027.textproto
@@ -23,10 +23,10 @@ test_vector_metadata {
     "3.11.1/output_gain"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -39,11 +39,9 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
       output_gain: 1
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000028.textproto
+++ b/iamf/cli/testdata/test_000028.textproto
@@ -23,10 +23,10 @@ test_vector_metadata {
     "3.11.1/channel_mapping_family"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -39,10 +39,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
       mapping_family: 1
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000

--- a/iamf/cli/testdata/test_000029.textproto
+++ b/iamf/cli/testdata/test_000029.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000030.textproto
+++ b/iamf/cli/testdata/test_000030.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000031.textproto
+++ b/iamf/cli/testdata/test_000031.textproto
@@ -24,7 +24,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000032.textproto
+++ b/iamf/cli/testdata/test_000032.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "3.11.1/target_bitrate"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 24000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000033.textproto
+++ b/iamf/cli/testdata/test_000033.textproto
@@ -24,10 +24,10 @@ test_vector_metadata {
     "3.11.1/target_bitrate"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -40,11 +40,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 96000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000034.textproto
+++ b/iamf/cli/testdata/test_000034.textproto
@@ -24,10 +24,10 @@ test_vector_metadata {
     "3.11.1/application"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -40,11 +40,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_VOIP

--- a/iamf/cli/testdata/test_000035.textproto
+++ b/iamf/cli/testdata/test_000035.textproto
@@ -24,10 +24,10 @@ test_vector_metadata {
     "3.11.1/application"
   ]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -40,11 +40,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 120
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_RESTRICTED_LOWDELAY

--- a/iamf/cli/testdata/test_000036.textproto
+++ b/iamf/cli/testdata/test_000036.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000037.textproto
+++ b/iamf/cli/testdata/test_000037.textproto
@@ -20,10 +20,10 @@ test_vector_metadata {
   mp4_fixed_timestamp: "2023-05-12 00:00:00"
   primary_tested_spec_sections: ["6/ISOBMFF IAMF Encapsulation"]
   base_test: "test_000020"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -36,11 +36,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000038.textproto
+++ b/iamf/cli/testdata/test_000038.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000039.textproto
+++ b/iamf/cli/testdata/test_000039.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000040.textproto
+++ b/iamf/cli/testdata/test_000040.textproto
@@ -24,7 +24,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000042.textproto
+++ b/iamf/cli/testdata/test_000042.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000043.textproto
+++ b/iamf/cli/testdata/test_000043.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000044.textproto
+++ b/iamf/cli/testdata/test_000044.textproto
@@ -32,7 +32,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000045.textproto
+++ b/iamf/cli/testdata/test_000045.textproto
@@ -24,10 +24,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000038"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -40,11 +40,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000046.textproto
+++ b/iamf/cli/testdata/test_000046.textproto
@@ -24,10 +24,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000043"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -40,11 +40,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000048.textproto
+++ b/iamf/cli/testdata/test_000048.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "7.3.2.2/Rendering a Scene-Based Audio Element to Loudspeakers"
   ]
   base_test: "test_000042"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000049.textproto
+++ b/iamf/cli/testdata/test_000049.textproto
@@ -28,10 +28,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000036"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,11 +44,8 @@ codec_config_metadata {
     audio_roll_distance: -2
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000050.textproto
+++ b/iamf/cli/testdata/test_000050.textproto
@@ -35,10 +35,10 @@ test_vector_metadata {
     "7.3.2.1/Rendering a Channel-Based Audio Element to Loudspeakers"
   ]
   base_test: "test_000037"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -51,11 +51,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000051.textproto
+++ b/iamf/cli/testdata/test_000051.textproto
@@ -28,10 +28,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000050"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,11 +44,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000052.textproto
+++ b/iamf/cli/testdata/test_000052.textproto
@@ -31,10 +31,10 @@ test_vector_metadata {
     "7.3.2.1/Rendering a Channel-Based Audio Element to Loudspeakers"
   ]
   base_test: "test_000051"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -47,11 +47,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000053.textproto
+++ b/iamf/cli/testdata/test_000053.textproto
@@ -28,10 +28,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000051"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,11 +44,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000054.textproto
+++ b/iamf/cli/testdata/test_000054.textproto
@@ -30,10 +30,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000050"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -46,11 +46,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000055.textproto
+++ b/iamf/cli/testdata/test_000055.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000054"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000056.textproto
+++ b/iamf/cli/testdata/test_000056.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000055"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000058.textproto
+++ b/iamf/cli/testdata/test_000058.textproto
@@ -28,7 +28,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000059.textproto
+++ b/iamf/cli/testdata/test_000059.textproto
@@ -29,10 +29,10 @@ test_vector_metadata {
     "7.3.2.1/Rendering a Channel-Based Audio Element to Loudspeakers"
   ]
   base_test: "test_000056"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -45,11 +45,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000060.textproto
+++ b/iamf/cli/testdata/test_000060.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000061.textproto
+++ b/iamf/cli/testdata/test_000061.textproto
@@ -31,10 +31,10 @@ test_vector_metadata {
     "7.3.2.1/Rendering a Channel-Based Audio Element to Loudspeakers"
   ]
   base_test: "test_000056"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -47,11 +47,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000062.textproto
+++ b/iamf/cli/testdata/test_000062.textproto
@@ -28,7 +28,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000063.textproto
+++ b/iamf/cli/testdata/test_000063.textproto
@@ -28,7 +28,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000064.textproto
+++ b/iamf/cli/testdata/test_000064.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000065.textproto
+++ b/iamf/cli/testdata/test_000065.textproto
@@ -28,7 +28,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000066.textproto
+++ b/iamf/cli/testdata/test_000066.textproto
@@ -34,7 +34,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000067.textproto
+++ b/iamf/cli/testdata/test_000067.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000068.textproto
+++ b/iamf/cli/testdata/test_000068.textproto
@@ -34,7 +34,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000069.textproto
+++ b/iamf/cli/testdata/test_000069.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000070.textproto
+++ b/iamf/cli/testdata/test_000070.textproto
@@ -37,7 +37,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000071.textproto
+++ b/iamf/cli/testdata/test_000071.textproto
@@ -37,7 +37,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000072.textproto
+++ b/iamf/cli/testdata/test_000072.textproto
@@ -26,7 +26,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -47,13 +46,9 @@ codec_config_metadata {
         stream_info {
           minimum_block_size: 64
           maximum_block_size: 64
-          minimum_frame_size: 0
-          maximum_frame_size: 0
           sample_rate: 48000
-          number_of_channels: 1  # Flac interprets this as 2 channels.
           bits_per_sample: 15  # Flac interprets this as 16 bits.
           total_samples_in_stream: 24000
-          md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         }
       }
       flac_encoder_metadata {

--- a/iamf/cli/testdata/test_000073.textproto
+++ b/iamf/cli/testdata/test_000073.textproto
@@ -30,7 +30,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -51,13 +50,9 @@ codec_config_metadata {
         stream_info {
           minimum_block_size: 512
           maximum_block_size: 512
-          minimum_frame_size: 0
-          maximum_frame_size: 0
           sample_rate: 48000
-          number_of_channels: 1  # Flac interprets this as 2 channels.
           bits_per_sample: 15  # Flac interprets this as 16 bits.
           total_samples_in_stream: 647851
-          md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         }
       }
       flac_encoder_metadata {

--- a/iamf/cli/testdata/test_000074.textproto
+++ b/iamf/cli/testdata/test_000074.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -48,13 +47,9 @@ codec_config_metadata {
         stream_info {
           minimum_block_size: 64
           maximum_block_size: 64
-          minimum_frame_size: 0
-          maximum_frame_size: 0
           sample_rate: 48000
-          number_of_channels: 1  # Flac interprets this as 2 channels.
           bits_per_sample: 15  # Flac interprets this as 16 bits.
           total_samples_in_stream: 24000
-          md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         }
       }
       flac_encoder_metadata {

--- a/iamf/cli/testdata/test_000075.textproto
+++ b/iamf/cli/testdata/test_000075.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -48,13 +47,9 @@ codec_config_metadata {
         stream_info {
           minimum_block_size: 64
           maximum_block_size: 64
-          minimum_frame_size: 0
-          maximum_frame_size: 0
           sample_rate: 48000
-          number_of_channels: 1  # Flac interprets this as 2 channels.
           bits_per_sample: 15  # Flac interprets this as 16 bits.
           total_samples_in_stream: 24000
-          md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         }
       }
       flac_encoder_metadata {

--- a/iamf/cli/testdata/test_000076.textproto
+++ b/iamf/cli/testdata/test_000076.textproto
@@ -26,7 +26,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -38,23 +37,11 @@ codec_config_metadata {
     num_samples_per_frame: 1024
     audio_roll_distance: -1
     decoder_config_aac: {
-      decoder_config_descriptor_tag: 0x04
-      object_type_indication: 0x40
-      stream_type: 0x05
-      upstream: 0
       buffer_size_db: 0
       max_bitrate: 0
       average_bit_rate: 0
       decoder_specific_info {
-        decoder_specific_info_descriptor_tag: 0x05
-        audio_object_type: 2
         sample_frequency_index: AAC_SAMPLE_FREQUENCY_INDEX_48000
-        channel_configuration: 2
-      }
-      ga_specific_config {
-        frame_length_flag: false
-        depends_on_core_coder: false
-        extension_flag: false
       }
       aac_encoder_metadata {
         bitrate_mode: 0  #  Constant bit rate mode.

--- a/iamf/cli/testdata/test_000077.textproto
+++ b/iamf/cli/testdata/test_000077.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000078.textproto
+++ b/iamf/cli/testdata/test_000078.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000079.textproto
+++ b/iamf/cli/testdata/test_000079.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000080.textproto
+++ b/iamf/cli/testdata/test_000080.textproto
@@ -30,10 +30,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000054"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -46,11 +46,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000081.textproto
+++ b/iamf/cli/testdata/test_000081.textproto
@@ -34,10 +34,10 @@ test_vector_metadata {
     "7.3.2.1/Rendering a Channel-Based Audio Element to Loudspeakers"
   ]
   base_test: "test_000054"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -50,11 +50,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000082.textproto
+++ b/iamf/cli/testdata/test_000082.textproto
@@ -30,7 +30,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000083.textproto
+++ b/iamf/cli/testdata/test_000083.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000084.textproto
+++ b/iamf/cli/testdata/test_000084.textproto
@@ -26,7 +26,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -47,13 +46,9 @@ codec_config_metadata {
         stream_info {
           minimum_block_size: 64
           maximum_block_size: 64
-          minimum_frame_size: 0
-          maximum_frame_size: 0
           sample_rate: 48000
-          number_of_channels: 1  # Flac interprets this as 2 channels.
           bits_per_sample: 15  # Flac interprets this as 16 bits.
           total_samples_in_stream: 24000
-          md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         }
       }
       flac_encoder_metadata {

--- a/iamf/cli/testdata/test_000085.textproto
+++ b/iamf/cli/testdata/test_000085.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000086.textproto
+++ b/iamf/cli/testdata/test_000086.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000087.textproto
+++ b/iamf/cli/testdata/test_000087.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "8.5.1/Loudness Information"
   ]
   base_test: "test_000405"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000088.textproto
+++ b/iamf/cli/testdata/test_000088.textproto
@@ -43,7 +43,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000089.textproto
+++ b/iamf/cli/testdata/test_000089.textproto
@@ -35,10 +35,10 @@ test_vector_metadata {
     "7.3.2.1/Rendering a Channel-Based Audio Element to Loudspeakers"
   ]
   base_test: "test_000050"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -51,11 +51,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000090.textproto
+++ b/iamf/cli/testdata/test_000090.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -39,23 +38,11 @@ codec_config_metadata {
     num_samples_per_frame: 1024
     audio_roll_distance: -1
     decoder_config_aac: {
-      decoder_config_descriptor_tag: 0x04
-      object_type_indication: 0x40
-      stream_type: 0x05
-      upstream: 0
       buffer_size_db: 0
       max_bitrate: 0
       average_bit_rate: 0
       decoder_specific_info {
-        decoder_specific_info_descriptor_tag: 0x05
-        audio_object_type: 2
         sample_frequency_index: AAC_SAMPLE_FREQUENCY_INDEX_48000
-        channel_configuration: 2
-      }
-      ga_specific_config {
-        frame_length_flag: false
-        depends_on_core_coder: false
-        extension_flag: false
       }
       aac_encoder_metadata {
         bitrate_mode: 0  #  Constant bit rate mode.

--- a/iamf/cli/testdata/test_000091.textproto
+++ b/iamf/cli/testdata/test_000091.textproto
@@ -26,7 +26,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -38,23 +37,11 @@ codec_config_metadata {
     num_samples_per_frame: 1024
     audio_roll_distance: 0
     decoder_config_aac: {
-      decoder_config_descriptor_tag: 0x04
-      object_type_indication: 0x40
-      stream_type: 0x05
-      upstream: 0
       buffer_size_db: 0
       max_bitrate: 0
       average_bit_rate: 0
       decoder_specific_info {
-        decoder_specific_info_descriptor_tag: 0x05
-        audio_object_type: 2
         sample_frequency_index: AAC_SAMPLE_FREQUENCY_INDEX_48000
-        channel_configuration: 2
-      }
-      ga_specific_config {
-        frame_length_flag: false
-        depends_on_core_coder: false
-        extension_flag: false
       }
       aac_encoder_metadata {
         bitrate_mode: 0  #  Constant bit rate mode.

--- a/iamf/cli/testdata/test_000092.textproto
+++ b/iamf/cli/testdata/test_000092.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -43,23 +42,11 @@ codec_config_metadata {
     num_samples_per_frame: 1024
     audio_roll_distance: -1
     decoder_config_aac: {
-      decoder_config_descriptor_tag: 0x04
-      object_type_indication: 0x40
-      stream_type: 0x05
-      upstream: 0
       buffer_size_db: 0
       max_bitrate: 0
       average_bit_rate: 0
       decoder_specific_info {
-        decoder_specific_info_descriptor_tag: 0x05
-        audio_object_type: 2
         sample_frequency_index: AAC_SAMPLE_FREQUENCY_INDEX_48000
-        channel_configuration: 2
-      }
-      ga_specific_config {
-        frame_length_flag: false
-        depends_on_core_coder: false
-        extension_flag: false
       }
       aac_encoder_metadata {
         bitrate_mode: 0  #  Constant bit rate mode.

--- a/iamf/cli/testdata/test_000093.textproto
+++ b/iamf/cli/testdata/test_000093.textproto
@@ -32,7 +32,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,23 +43,11 @@ codec_config_metadata {
     num_samples_per_frame: 1024
     audio_roll_distance: -1
     decoder_config_aac: {
-      decoder_config_descriptor_tag: 0x04
-      object_type_indication: 0x40
-      stream_type: 0x05
-      upstream: 0
       buffer_size_db: 0
       max_bitrate: 0
       average_bit_rate: 0
       decoder_specific_info {
-        decoder_specific_info_descriptor_tag: 0x05
-        audio_object_type: 2
         sample_frequency_index: AAC_SAMPLE_FREQUENCY_INDEX_48000
-        channel_configuration: 2
-      }
-      ga_specific_config {
-        frame_length_flag: false
-        depends_on_core_coder: false
-        extension_flag: false
       }
       aac_encoder_metadata {
         bitrate_mode: 0  #  Constant bit rate mode.

--- a/iamf/cli/testdata/test_000094.textproto
+++ b/iamf/cli/testdata/test_000094.textproto
@@ -30,7 +30,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,23 +41,11 @@ codec_config_metadata {
     num_samples_per_frame: 1024
     audio_roll_distance: -1
     decoder_config_aac: {
-      decoder_config_descriptor_tag: 0x04
-      object_type_indication: 0x40
-      stream_type: 0x05
-      upstream: 0
       buffer_size_db: 0
       max_bitrate: 0
       average_bit_rate: 0
       decoder_specific_info {
-        decoder_specific_info_descriptor_tag: 0x05
-        audio_object_type: 2
         sample_frequency_index: AAC_SAMPLE_FREQUENCY_INDEX_48000
-        channel_configuration: 2
-      }
-      ga_specific_config {
-        frame_length_flag: false
-        depends_on_core_coder: false
-        extension_flag: false
       }
       aac_encoder_metadata {
         bitrate_mode: 0  #  Constant bit rate mode.

--- a/iamf/cli/testdata/test_000095.textproto
+++ b/iamf/cli/testdata/test_000095.textproto
@@ -40,7 +40,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000096.textproto
+++ b/iamf/cli/testdata/test_000096.textproto
@@ -30,7 +30,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000097.textproto
+++ b/iamf/cli/testdata/test_000097.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000098.textproto
+++ b/iamf/cli/testdata/test_000098.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -2
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000100.textproto
+++ b/iamf/cli/testdata/test_000100.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000101.textproto
+++ b/iamf/cli/testdata/test_000101.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000102.textproto
+++ b/iamf/cli/testdata/test_000102.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000103.textproto
+++ b/iamf/cli/testdata/test_000103.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000104.textproto
+++ b/iamf/cli/testdata/test_000104.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000105.textproto
+++ b/iamf/cli/testdata/test_000105.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000106.textproto
+++ b/iamf/cli/testdata/test_000106.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000107.textproto
+++ b/iamf/cli/testdata/test_000107.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000108.textproto
+++ b/iamf/cli/testdata/test_000108.textproto
@@ -23,10 +23,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000100"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -39,11 +39,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000109.textproto
+++ b/iamf/cli/testdata/test_000109.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000101"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000110.textproto
+++ b/iamf/cli/testdata/test_000110.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000102"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000111.textproto
+++ b/iamf/cli/testdata/test_000111.textproto
@@ -25,10 +25,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000103"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -41,11 +41,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000112.textproto
+++ b/iamf/cli/testdata/test_000112.textproto
@@ -23,10 +23,10 @@ test_vector_metadata {
     "3.11.1/OPUS Specific"
   ]
   base_test: "test_000104"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -39,11 +39,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000113.textproto
+++ b/iamf/cli/testdata/test_000113.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000105"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000114.textproto
+++ b/iamf/cli/testdata/test_000114.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000106"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000115.textproto
+++ b/iamf/cli/testdata/test_000115.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000107"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000200.textproto
+++ b/iamf/cli/testdata/test_000200.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000201.textproto
+++ b/iamf/cli/testdata/test_000201.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000202.textproto
+++ b/iamf/cli/testdata/test_000202.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000203.textproto
+++ b/iamf/cli/testdata/test_000203.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000204.textproto
+++ b/iamf/cli/testdata/test_000204.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000205.textproto
+++ b/iamf/cli/testdata/test_000205.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000206.textproto
+++ b/iamf/cli/testdata/test_000206.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000207.textproto
+++ b/iamf/cli/testdata/test_000207.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000208.textproto
+++ b/iamf/cli/testdata/test_000208.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000209.textproto
+++ b/iamf/cli/testdata/test_000209.textproto
@@ -32,7 +32,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000210.textproto
+++ b/iamf/cli/testdata/test_000210.textproto
@@ -32,7 +32,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000211.textproto
+++ b/iamf/cli/testdata/test_000211.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000212.textproto
+++ b/iamf/cli/testdata/test_000212.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000200"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000213.textproto
+++ b/iamf/cli/testdata/test_000213.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000201"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000214.textproto
+++ b/iamf/cli/testdata/test_000214.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000202"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000215.textproto
+++ b/iamf/cli/testdata/test_000215.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000203"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000216.textproto
+++ b/iamf/cli/testdata/test_000216.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000204"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000217.textproto
+++ b/iamf/cli/testdata/test_000217.textproto
@@ -28,10 +28,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000205"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,11 +44,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000218.textproto
+++ b/iamf/cli/testdata/test_000218.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000206"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000219.textproto
+++ b/iamf/cli/testdata/test_000219.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "3.11.1/pre_skip"
   ]
   base_test: "test_000207"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000220.textproto
+++ b/iamf/cli/testdata/test_000220.textproto
@@ -28,10 +28,10 @@ test_vector_metadata {
     "7.5.2/Limiter"
   ]
   base_test: "test_000208"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,11 +44,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000221.textproto
+++ b/iamf/cli/testdata/test_000221.textproto
@@ -28,10 +28,10 @@ test_vector_metadata {
     "9.1.2.1/Annex A2.1: Down-mix parameter and Loudness"
   ]
   base_test: "test_000209"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -44,11 +44,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000222.textproto
+++ b/iamf/cli/testdata/test_000222.textproto
@@ -29,10 +29,10 @@ test_vector_metadata {
     "9.1.2.1/Annex A2.1: Down-mix parameter and Loudness"
   ]
   base_test: "test_000221"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -45,11 +45,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000223.textproto
+++ b/iamf/cli/testdata/test_000223.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "9.1.2.1/Annex A2.1: Down-mix parameter and Loudness"
   ]
   base_test: "test_000223"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000224.textproto
+++ b/iamf/cli/testdata/test_000224.textproto
@@ -35,7 +35,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000225.textproto
+++ b/iamf/cli/testdata/test_000225.textproto
@@ -41,7 +41,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000226.textproto
+++ b/iamf/cli/testdata/test_000226.textproto
@@ -36,7 +36,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000227.textproto
+++ b/iamf/cli/testdata/test_000227.textproto
@@ -38,11 +38,11 @@ test_vector_metadata {
     "9.1.2.4/Annex A2.4: Channel Group Generation Rule"
   ]
   base_test: "test_000224"
+  output_wav_file_bit_depth_override: 16
   override_computed_recon_gains: true
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -55,11 +55,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 96000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000228.textproto
+++ b/iamf/cli/testdata/test_000228.textproto
@@ -39,11 +39,11 @@ test_vector_metadata {
     "9.1.2.4/Annex A2.4: Channel Group Generation Rule"
   ]
   base_test: "test_000225"
+  output_wav_file_bit_depth_override: 16
   override_computed_recon_gains: true
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -56,11 +56,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000229.textproto
+++ b/iamf/cli/testdata/test_000229.textproto
@@ -39,11 +39,11 @@ test_vector_metadata {
     "9.1.2.4/Annex A2.4: Channel Group Generation Rule"
   ]
   base_test: "test_000226"
+  output_wav_file_bit_depth_override: 16
   override_computed_recon_gains: true
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -56,11 +56,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000230.textproto
+++ b/iamf/cli/testdata/test_000230.textproto
@@ -40,11 +40,11 @@ test_vector_metadata {
     "9.1.2.4/Annex A2.4: Channel Group Generation Rule"
   ]
   base_test: "test_000226"
+  output_wav_file_bit_depth_override: 16
   override_computed_recon_gains: true
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -57,11 +57,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000231.textproto
+++ b/iamf/cli/testdata/test_000231.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000300.textproto
+++ b/iamf/cli/testdata/test_000300.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000301.textproto
+++ b/iamf/cli/testdata/test_000301.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000302.textproto
+++ b/iamf/cli/testdata/test_000302.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000303.textproto
+++ b/iamf/cli/testdata/test_000303.textproto
@@ -28,10 +28,10 @@ test_vector_metadata {
     "8.5.1/Loudness Information"
   ]
   base_test: "test_000109"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }
@@ -44,11 +44,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000304.textproto
+++ b/iamf/cli/testdata/test_000304.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "8.5.1/Loudness Information"
   ]
   base_test: "test_000110"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000305.textproto
+++ b/iamf/cli/testdata/test_000305.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "8.5.1/Loudness Information"
   ]
   base_test: "test_000111"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000400.textproto
+++ b/iamf/cli/testdata/test_000400.textproto
@@ -28,7 +28,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000401.textproto
+++ b/iamf/cli/testdata/test_000401.textproto
@@ -30,7 +30,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000402.textproto
+++ b/iamf/cli/testdata/test_000402.textproto
@@ -29,7 +29,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000403.textproto
+++ b/iamf/cli/testdata/test_000403.textproto
@@ -26,10 +26,10 @@ test_vector_metadata {
     "8.5.1/Loudness Information"
   ]
   base_test: "test_000303"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }
@@ -42,11 +42,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000404.textproto
+++ b/iamf/cli/testdata/test_000404.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "8.5.1/Loudness Information"
   ]
   base_test: "test_000403"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000405.textproto
+++ b/iamf/cli/testdata/test_000405.textproto
@@ -27,10 +27,10 @@ test_vector_metadata {
     "8.5.1/Loudness Information"
   ]
   base_test: "test_000404"
+  output_wav_file_bit_depth_override: 16
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }
@@ -43,11 +43,8 @@ codec_config_metadata {
     audio_roll_distance: -4
     decoder_config_opus {
       version: 1
-      output_channel_count: 2
       pre_skip: 312
       input_sample_rate: 48000
-      output_gain: 0
-      mapping_family: 0
       opus_encoder_metadata {
         target_bitrate_per_channel: 48000
         application: APPLICATION_AUDIO

--- a/iamf/cli/testdata/test_000406.textproto
+++ b/iamf/cli/testdata/test_000406.textproto
@@ -23,7 +23,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000407.textproto
+++ b/iamf/cli/testdata/test_000407.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000408.textproto
+++ b/iamf/cli/testdata/test_000408.textproto
@@ -31,7 +31,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000409.textproto
+++ b/iamf/cli/testdata/test_000409.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000500.textproto
+++ b/iamf/cli/testdata/test_000500.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }
@@ -48,13 +47,9 @@ codec_config_metadata {
         stream_info {
           minimum_block_size: 64
           maximum_block_size: 64
-          minimum_frame_size: 0
-          maximum_frame_size: 0
           sample_rate: 48000
-          number_of_channels: 1  # Flac interprets this as 2 channels.
           bits_per_sample: 15  # Flac interprets this as 16 bits.
           total_samples_in_stream: 24000
-          md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         }
       }
       flac_encoder_metadata {

--- a/iamf/cli/testdata/test_000501.textproto
+++ b/iamf/cli/testdata/test_000501.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/testdata/test_000502.textproto
+++ b/iamf/cli/testdata/test_000502.textproto
@@ -25,7 +25,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_BASE
   additional_profile: PROFILE_VERSION_BASE
 }

--- a/iamf/cli/testdata/test_000503.textproto
+++ b/iamf/cli/testdata/test_000503.textproto
@@ -27,7 +27,6 @@ test_vector_metadata {
 }
 
 ia_sequence_header_metadata {
-  ia_code: 0x69616d66  # "iamf"
   primary_profile: PROFILE_VERSION_SIMPLE
   additional_profile: PROFILE_VERSION_SIMPLE
 }

--- a/iamf/cli/tests/BUILD
+++ b/iamf/cli/tests/BUILD
@@ -47,6 +47,7 @@ cc_test(
         "//iamf:obu_header",
         "//iamf/cli:aac_encoder_decoder",
         "//iamf/cli/proto:codec_config_cc_proto",
+        "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -166,6 +167,7 @@ cc_test(
         "//iamf:aac_decoder_config",
         "//iamf:codec_config",
         "//iamf:flac_decoder_config",
+        "//iamf:ia",
         "//iamf:lpcm_decoder_config",
         "//iamf:obu_header",
         "//iamf:opus_decoder_config",
@@ -175,6 +177,7 @@ cc_test(
         "//iamf/cli/proto:test_vector_metadata_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
     ],
@@ -470,6 +473,27 @@ cc_test(
     deps = [
         "//iamf/cli:wav_reader",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "wav_sample_provider_test",
+    srcs = ["wav_sample_provider_test.cc"],
+    data = [
+        "//iamf/cli/testdata:stereo_8_samples_48khz_s16le.wav",
+        "//iamf/cli/testdata:stereo_8_samples_48khz_s24le.wav",
+    ],
+    deps = [
+        ":cli_test_utils",
+        "//iamf:codec_config",
+        "//iamf:ia",
+        "//iamf/cli:audio_element_with_data",
+        "//iamf/cli:demixing_module",
+        "//iamf/cli:wav_sample_provider",
+        "//iamf/cli/proto:user_metadata_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/iamf/cli/tests/cli_test_utils.cc
+++ b/iamf/cli/tests/cli_test_utils.cc
@@ -59,18 +59,13 @@ void AddOpusCodecConfigWithId(
   // Initialize the Codec Config OBU.
   ASSERT_EQ(codec_config_obus.find(codec_config_id), codec_config_obus.end());
 
-  CodecConfigObu obu(ObuHeader(), codec_config_id,
-                     {.codec_id = CodecConfig::kCodecIdOpus,
-                      .num_samples_per_frame = 8,
-                      .audio_roll_distance = 0,
-                      .decoder_config = OpusDecoderConfig{
-                          .version_ = 1,
-                          .output_channel_count_ = 2,
-                          .pre_skip_ = 312,
-                          .input_sample_rate_ = 0,
-                          .output_gain_ = 0,
-                          .mapping_family_ = 0,
-                      }});
+  CodecConfigObu obu(
+      ObuHeader(), codec_config_id,
+      {.codec_id = CodecConfig::kCodecIdOpus,
+       .num_samples_per_frame = 8,
+       .audio_roll_distance = 0,
+       .decoder_config = OpusDecoderConfig{
+           .version_ = 1, .pre_skip_ = 312, .input_sample_rate_ = 0}});
   ASSERT_TRUE(obu.Initialize().ok());
   codec_config_obus.emplace(codec_config_id, std::move(obu));
 }

--- a/iamf/cli/tests/codec_config_generator_test.cc
+++ b/iamf/cli/tests/codec_config_generator_test.cc
@@ -11,12 +11,14 @@
  */
 #include "iamf/cli/codec_config_generator.h"
 
+#include <array>
 #include <cstdint>
 #include <limits>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "gtest/gtest.h"
 #include "iamf/aac_decoder_config.h"
 #include "iamf/cli/proto/codec_config.pb.h"
@@ -24,6 +26,7 @@
 #include "iamf/cli/proto/test_vector_metadata.pb.h"
 #include "iamf/codec_config.h"
 #include "iamf/flac_decoder_config.h"
+#include "iamf/ia.h"
 #include "iamf/lpcm_decoder_config.h"
 #include "iamf/obu_header.h"
 #include "iamf/opus_decoder_config.h"
@@ -33,150 +36,47 @@
 namespace iamf_tools {
 namespace {
 
-class CodecConfigGeneratorTest : public testing::Test {
- public:
-  CodecConfigGeneratorTest() {
-    google::protobuf::TextFormat::ParseFromString(
-        R"pb(
-          codec_config_id: 0
-          codec_config {
-            codec_id: CODEC_ID_LPCM
-            num_samples_per_frame: 64
-            audio_roll_distance: 0
-            decoder_config_lpcm {
-              sample_format_flags: LPCM_LITTLE_ENDIAN
-              sample_size: 16
-              sample_rate: 16000
-            }
-          }
-        )pb",
-        codec_config_metadata_.Add());
-  }
+const DecodedUleb128 kCodecConfigId = 200;
 
-  void InitAndTestGenerate() {
-    // The generator initializes all OBUs. Make sure expected OBUs are
-    // initialized.
-    for (auto& [codec_config_id, obu] : expected_obus_) {
-      ASSERT_TRUE(obu.Initialize().ok());
-    }
-
-    // Generate the OBUs.
-    absl::flat_hash_map<uint32_t, CodecConfigObu> output_obus;
-    CodecConfigGenerator generator(codec_config_metadata_);
-    EXPECT_EQ(generator.Generate(output_obus).code(),
-              expected_generate_status_code_);
-
-    EXPECT_EQ(expected_obus_, output_obus);
-  }
-
- protected:
-  ::google::protobuf::RepeatedPtrField<
-      iamf_tools_cli_proto::CodecConfigObuMetadata>
-      codec_config_metadata_;
-  absl::StatusCode expected_generate_status_code_ = absl::StatusCode::kOk;
-  absl::flat_hash_map<uint32_t, CodecConfigObu> expected_obus_;
-};
-
-TEST_F(CodecConfigGeneratorTest, DefaultLpcm) {
-  expected_obus_.emplace(
-      0, CodecConfigObu(
-             ObuHeader(), 0,
-             {.codec_id = CodecConfig::kCodecIdLpcm,
-              .num_samples_per_frame = 64,
-              .audio_roll_distance = 0,
-              .decoder_config = LpcmDecoderConfig{
-                  .sample_format_flags_ = LpcmDecoderConfig::kLpcmLittleEndian,
-                  .sample_size_ = 16,
-                  .sample_rate_ = 16000}}));
-  InitAndTestGenerate();
-}
-
-TEST_F(CodecConfigGeneratorTest, RedundantCopy) {
-  codec_config_metadata_.at(0).mutable_obu_header()->set_obu_redundant_copy(
-      true);
-
-  expected_obus_.emplace(
-      0, CodecConfigObu(
-             ObuHeader{.obu_redundant_copy = true}, 0,
-             {.codec_id = CodecConfig::kCodecIdLpcm,
-              .num_samples_per_frame = 64,
-              .audio_roll_distance = 0,
-              .decoder_config = LpcmDecoderConfig{
-                  .sample_format_flags_ = LpcmDecoderConfig::kLpcmLittleEndian,
-                  .sample_size_ = 16,
-                  .sample_rate_ = 16000}}));
-  InitAndTestGenerate();
-}
-
-TEST_F(CodecConfigGeneratorTest, ExtensionHeader) {
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+void InitMetadataForLpcm(
+    ::google::protobuf::RepeatedPtrField<
+        iamf_tools_cli_proto::CodecConfigObuMetadata>& codec_config_metadata) {
+  google::protobuf::TextFormat::ParseFromString(
       R"pb(
-        obu_extension_flag: true
-        extension_header_size: 5
-        extension_header_bytes: "extra"
+        codec_config_id: 200
+        codec_config {
+          codec_id: CODEC_ID_LPCM
+          num_samples_per_frame: 64
+          audio_roll_distance: 0
+          decoder_config_lpcm {
+            sample_format_flags: LPCM_LITTLE_ENDIAN
+            sample_size: 16
+            sample_rate: 16000
+          }
+        }
       )pb",
-      codec_config_metadata_.at(0).mutable_obu_header()));
-
-  expected_obus_.emplace(
-      0, CodecConfigObu(
-             ObuHeader{.obu_extension_flag = true,
-                       .extension_header_size = 5,
-                       .extension_header_bytes = {'e', 'x', 't', 'r', 'a'}},
-             0,
-             {.codec_id = CodecConfig::CodecConfig::kCodecIdLpcm,
-              .num_samples_per_frame = 64,
-              .audio_roll_distance = 0,
-              .decoder_config = LpcmDecoderConfig{
-                  .sample_format_flags_ = LpcmDecoderConfig::kLpcmLittleEndian,
-                  .sample_size_ = 16,
-                  .sample_rate_ = 16000}}));
-  InitAndTestGenerate();
+      codec_config_metadata.Add());
 }
 
-TEST_F(CodecConfigGeneratorTest, NoCodecConfigObus) {
-  codec_config_metadata_.Clear();
-  InitAndTestGenerate();
+void InitExpectedObuForLpcm(
+    absl::flat_hash_map<uint32_t, CodecConfigObu>& expected_obus) {
+  expected_obus.emplace(
+      kCodecConfigId,
+      CodecConfigObu(
+          ObuHeader(), kCodecConfigId,
+          {.codec_id = CodecConfig::kCodecIdLpcm,
+           .num_samples_per_frame = 64,
+           .audio_roll_distance = 0,
+           .decoder_config = LpcmDecoderConfig{
+               .sample_format_flags_ = LpcmDecoderConfig::kLpcmLittleEndian,
+               .sample_size_ = 16,
+               .sample_rate_ = 16000}}));
+  ASSERT_TRUE(expected_obus.at(kCodecConfigId).Initialize().ok());
 }
 
-TEST_F(CodecConfigGeneratorTest, FallsBackToDeprecatedCodecIdField) {
-  // `deprecated_codec_id` is used as a fallback when `codec_id` is missing.
-  codec_config_metadata_.at(0).mutable_codec_config()->clear_codec_id();
-  codec_config_metadata_.at(0).mutable_codec_config()->set_deprecated_codec_id(
-      CodecConfig::kCodecIdLpcm);
-
-  expected_obus_.emplace(
-      0, CodecConfigObu(
-             ObuHeader(), 0,
-             {.codec_id = CodecConfig::kCodecIdLpcm,
-              .num_samples_per_frame = 64,
-              .audio_roll_distance = 0,
-              .decoder_config = LpcmDecoderConfig{
-                  .sample_format_flags_ = LpcmDecoderConfig::kLpcmLittleEndian,
-                  .sample_size_ = 16,
-                  .sample_rate_ = 16000}}));
-
-  InitAndTestGenerate();
-}
-
-TEST_F(CodecConfigGeneratorTest, UnknownCodecId) {
-  codec_config_metadata_.at(0).mutable_codec_config()->set_codec_id(
-      iamf_tools_cli_proto::CODEC_ID_INVALID);
-  expected_generate_status_code_ = absl::StatusCode::kInvalidArgument;
-
-  InitAndTestGenerate();
-}
-
-TEST_F(CodecConfigGeneratorTest, BadRollDistanceCast) {
-  codec_config_metadata_.at(0).mutable_codec_config()->set_audio_roll_distance(
-      std::numeric_limits<int16_t>::max() + 1);
-  expected_generate_status_code_ = absl::StatusCode::kInvalidArgument;
-
-  InitAndTestGenerate();
-}
-
-TEST_F(CodecConfigGeneratorTest, Opus) {
-  codec_config_metadata_.Clear();
-
+void InitMetadataForOpus(
+    ::google::protobuf::RepeatedPtrField<
+        iamf_tools_cli_proto::CodecConfigObuMetadata>& codec_config_metadata) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
         codec_config_id: 200
@@ -198,26 +98,26 @@ TEST_F(CodecConfigGeneratorTest, Opus) {
           }
         }
       )pb",
-      codec_config_metadata_.Add()));
-
-  expected_obus_.emplace(
-      200, CodecConfigObu(
-               ObuHeader(), 200,
-               {.codec_id = CodecConfig::CodecConfig::kCodecIdOpus,
-                .num_samples_per_frame = 120,
-                .audio_roll_distance = -32,
-                .decoder_config = OpusDecoderConfig{.version_ = 1,
-                                                    .output_channel_count_ = 2,
-                                                    .pre_skip_ = 0,
-                                                    .input_sample_rate_ = 48000,
-                                                    .output_gain_ = 0,
-                                                    .mapping_family_ = 0}}));
-  InitAndTestGenerate();
+      codec_config_metadata.Add()));
 }
 
-TEST_F(CodecConfigGeneratorTest, Aac) {
-  codec_config_metadata_.Clear();
+void InitExpectedObuForOpus(
+    absl::flat_hash_map<uint32_t, CodecConfigObu>& expected_obus) {
+  expected_obus.emplace(
+      kCodecConfigId,
+      CodecConfigObu(
+          ObuHeader(), kCodecConfigId,
+          {.codec_id = CodecConfig::CodecConfig::kCodecIdOpus,
+           .num_samples_per_frame = 120,
+           .audio_roll_distance = -32,
+           .decoder_config = OpusDecoderConfig{
+               .version_ = 1, .pre_skip_ = 0, .input_sample_rate_ = 48000}}));
+  ASSERT_TRUE(expected_obus.at(kCodecConfigId).Initialize().ok());
+}
 
+void InitMetadataForAac(
+    ::google::protobuf::RepeatedPtrField<
+        iamf_tools_cli_proto::CodecConfigObuMetadata>& codec_config_metadata) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
         codec_config_id: 200
@@ -252,45 +152,34 @@ TEST_F(CodecConfigGeneratorTest, Aac) {
           }
         }
       )pb",
-      codec_config_metadata_.Add()));
+      codec_config_metadata.Add()));
+}
 
-  expected_obus_.emplace(
-      200,
+void InitExpectedObuForAac(
+    absl::flat_hash_map<uint32_t, CodecConfigObu>& expected_obus) {
+  expected_obus.emplace(
+      kCodecConfigId,
       CodecConfigObu(
-          ObuHeader(), 200,
+          ObuHeader(), kCodecConfigId,
           {.codec_id = CodecConfig::kCodecIdAacLc,
            .num_samples_per_frame = 1024,
            .audio_roll_distance = -1,
            .decoder_config = AacDecoderConfig{
-               .decoder_config_descriptor_tag_ = 0x04,
-               .object_type_indication_ = 0x40,
-               .stream_type_ = 0x05,
-               .upstream_ = 0,
                .reserved_ = 0,
                .buffer_size_db_ = 0,
                .max_bitrate_ = 0,
                .average_bit_rate_ = 0,
                .decoder_specific_info_{
-                   .decoder_specific_info_tag = 0x05,
                    .audio_specific_config =
-                       {.audio_object_type_ = 2,
-                        .sample_frequency_index_ =
-                            AudioSpecificConfig::kSampleFrequencyIndex48000,
-                        .sampling_frequency_ = 0,
-                        .channel_configuration_ = 2,
-                        .ga_specific_config_ =
-                            {
-                                .frame_length_flag = 0,
-                                .depends_on_core_coder = 0,
-                                .extension_flag = 0,
-                            }}},
+                       {.sample_frequency_index_ =
+                            AudioSpecificConfig::kSampleFrequencyIndex48000}},
            }}));
-  InitAndTestGenerate();
+  ASSERT_TRUE(expected_obus.at(kCodecConfigId).Initialize().ok());
 }
 
-TEST_F(CodecConfigGeneratorTest, Flac) {
-  codec_config_metadata_.Clear();
-
+void InitMetadataForFlac(
+    ::google::protobuf::RepeatedPtrField<
+        iamf_tools_cli_proto::CodecConfigObuMetadata>& codec_config_metadata) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
         codec_config_id: 200
@@ -301,7 +190,7 @@ TEST_F(CodecConfigGeneratorTest, Flac) {
           decoder_config_flac: {
             metadata_blocks: {
               header: {
-                last_metadata_block_flag: false
+                last_metadata_block_flag: true
                 block_type: FLAC_BLOCK_TYPE_STREAMINFO
                 metadata_data_block_length: 34
               }
@@ -314,53 +203,718 @@ TEST_F(CodecConfigGeneratorTest, Flac) {
                 number_of_channels: 1  # Flac interprets this as 2 channels.
                 bits_per_sample: 15    # Flac interprets this as 16 bits.
                 total_samples_in_stream: 24000
-                md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                md5_signature: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                               "\x00\x00\x00\x00\x00"
               }
-            }
-            metadata_blocks: {
-              header: {
-                last_metadata_block_flag: true
-                block_type: FLAC_BLOCK_TYPE_PICTURE
-                metadata_data_block_length: 3
-              }
-              generic_block: "abc"
             }
             flac_encoder_metadata { compression_level: 0 }
 
           }
         }
       )pb",
-      codec_config_metadata_.Add()));
+      codec_config_metadata.Add()));
+}
 
-  expected_obus_.emplace(
-      200,
+void InitExpectedObuForFlac(
+    absl::flat_hash_map<uint32_t, CodecConfigObu>& expected_obus) {
+  expected_obus.emplace(
+      kCodecConfigId,
       CodecConfigObu(
-          ObuHeader(), 200,
+          ObuHeader(), kCodecConfigId,
           {.codec_id = CodecConfig::kCodecIdFlac,
            .num_samples_per_frame = 64,
            .audio_roll_distance = 0,
            .decoder_config = FlacDecoderConfig{
-               {{.header = {.last_metadata_block_flag = false,
+               {{.header = {.last_metadata_block_flag = true,
                             .block_type = FlacMetaBlockHeader::kFlacStreamInfo,
                             .metadata_data_block_length = 34},
-                 .payload =
-                     FlacMetaBlockStreamInfo{
-                         .minimum_block_size = 64,
-                         .maximum_block_size = 64,
-                         .minimum_frame_size = 0,
-                         .maximum_frame_size = 0,
-                         .sample_rate = 48000,
-                         .number_of_channels = 1,
-                         .bits_per_sample = 15,
-                         .total_samples_in_stream = 24000,
-                         .md5_signature = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                           0x00, 0x00, 0x00, 0x00}}},
-                {.header = {.last_metadata_block_flag = true,
-                            .block_type = FlacMetaBlockHeader::kFlacPicture,
-                            .metadata_data_block_length = 3},
-                 .payload = std::vector<uint8_t>({'a', 'b', 'c'})}}}}));
-  InitAndTestGenerate();
+                 .payload = FlacMetaBlockStreamInfo{
+                     .minimum_block_size = 64,
+                     .maximum_block_size = 64,
+                     .sample_rate = 48000,
+                     .bits_per_sample = 15,
+                     .total_samples_in_stream = 24000}}}}}));
+  ASSERT_TRUE(expected_obus.at(kCodecConfigId).Initialize().ok());
+}
+
+class CodecConfigGeneratorTest : public testing::Test {
+ public:
+  CodecConfigGeneratorTest() = default;
+
+  absl::StatusOr<absl::flat_hash_map<uint32_t, CodecConfigObu>>
+  InitAndGenerate() {
+    // Generate the OBUs.
+    absl::flat_hash_map<uint32_t, CodecConfigObu> output_obus;
+    CodecConfigGenerator generator(codec_config_metadata_);
+
+    if (const auto status = generator.Generate(output_obus); status.ok()) {
+      return output_obus;
+    } else {
+      return status;
+    }
+  }
+
+ protected:
+  ::google::protobuf::RepeatedPtrField<
+      iamf_tools_cli_proto::CodecConfigObuMetadata>
+      codec_config_metadata_;
+  absl::flat_hash_map<uint32_t, CodecConfigObu> expected_obus_;
+};
+
+TEST_F(CodecConfigGeneratorTest, SucceedsGeneratingNoCodecConfigObus) {
+  codec_config_metadata_.Clear();
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_TRUE(output_obus->empty());
+}
+
+TEST_F(CodecConfigGeneratorTest, GeneratesObuForLpcm) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  InitExpectedObuForLpcm(expected_obus_);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(*output_obus, expected_obus_);
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidLpcmDecoderConfigIsMissing) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  ASSERT_EQ(codec_config_metadata_.at(0).codec_config().codec_id(),
+            iamf_tools_cli_proto::CODEC_ID_LPCM);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->clear_decoder_config_lpcm();
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, ConfiguresRedundantCopy) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  // Reconfigure the OBU to be a redundant copy.
+  codec_config_metadata_.at(0).mutable_obu_header()->set_obu_redundant_copy(
+      true);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(output_obus->at(kCodecConfigId).header_.obu_redundant_copy, true);
+}
+
+TEST_F(CodecConfigGeneratorTest, ConfiguresExtensionHeader) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  // Reconfigure the OBU to have an extension header.
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        obu_extension_flag: true
+        extension_header_size: 5
+        extension_header_bytes: "extra"
+      )pb",
+      codec_config_metadata_.at(0).mutable_obu_header()));
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(output_obus->at(kCodecConfigId).header_.obu_extension_flag, true);
+  EXPECT_EQ(output_obus->at(kCodecConfigId).header_.extension_header_size, 5);
+  EXPECT_EQ(output_obus->at(kCodecConfigId).header_.extension_header_bytes,
+            std::vector<uint8_t>({'e', 'x', 't', 'r', 'a'}));
+}
+
+TEST_F(CodecConfigGeneratorTest, ConfiguresLpcmBigEndian) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_lpcm()
+      ->set_sample_format_flags(iamf_tools_cli_proto::LPCM_BIG_ENDIAN);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(std::get<LpcmDecoderConfig>(
+                output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+                .sample_format_flags_,
+            LpcmDecoderConfig::kLpcmBigEndian);
+}
+
+TEST_F(CodecConfigGeneratorTest, FailsForUnknownSampleFormatFlags) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_lpcm()
+      ->set_sample_format_flags(iamf_tools_cli_proto::LPCM_INVALID);
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, FallsBackToDeprecatedCodecIdField) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  // `deprecated_codec_id` is used as a fallback when `codec_id` is missing.
+  codec_config_metadata_.at(0).mutable_codec_config()->clear_codec_id();
+  codec_config_metadata_.at(0).mutable_codec_config()->set_deprecated_codec_id(
+      CodecConfig::kCodecIdLpcm);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(output_obus->at(kCodecConfigId).codec_config_.codec_id,
+            CodecConfig::kCodecIdLpcm);
+}
+
+TEST_F(CodecConfigGeneratorTest, FailsForUnknownCodecId) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  codec_config_metadata_.at(0).mutable_codec_config()->set_codec_id(
+      iamf_tools_cli_proto::CODEC_ID_INVALID);
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, FailsWhenCodecIdIsMissing) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  codec_config_metadata_.at(0).mutable_codec_config()->clear_codec_id();
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, FailsWhenRollDistanceIsTooLarge) {
+  InitMetadataForLpcm(codec_config_metadata_);
+  // Roll distance must be castable to `int16_t`.
+  codec_config_metadata_.at(0).mutable_codec_config()->set_audio_roll_distance(
+      std::numeric_limits<int16_t>::max() + 1);
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, GeneratesObuForOpus) {
+  InitMetadataForOpus(codec_config_metadata_);
+  InitExpectedObuForOpus(expected_obus_);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(*output_obus, expected_obus_);
+}
+
+TEST_F(CodecConfigGeneratorTest, IamfOpusFixedFieldsMayBeOmitted) {
+  InitMetadataForOpus(codec_config_metadata_);
+  // Some fields are fixed in IAMF. It is OK to omit these from the input data.
+  auto* metadata_decodec_config_opus = codec_config_metadata_.at(0)
+                                           .mutable_codec_config()
+                                           ->mutable_decoder_config_opus();
+  metadata_decodec_config_opus->clear_output_channel_count();
+  metadata_decodec_config_opus->clear_output_gain();
+  metadata_decodec_config_opus->clear_mapping_family();
+  InitExpectedObuForOpus(expected_obus_);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(*output_obus, expected_obus_);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidOpusOutputChannelCount) {
+  // IAMF requires `output_channel_count` is fixed. The generator does not
+  // validate OBU requirements.
+  const uint8_t kInvalidOutputChannelCount = 99;
+  ASSERT_NE(kInvalidOutputChannelCount, OpusDecoderConfig::kOutputChannelCount);
+  InitMetadataForOpus(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_opus()
+      ->set_output_channel_count(kInvalidOutputChannelCount);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(std::get<OpusDecoderConfig>(
+                output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+                .output_channel_count_,
+            kInvalidOutputChannelCount);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidOpusOutputGain) {
+  // IAMF requires `output_gain` is fixed. The generator does not validate OBU
+  // requirements.
+  const uint8_t kInvalidOutputGain = 99;
+  ASSERT_NE(kInvalidOutputGain, OpusDecoderConfig::kOutputGain);
+  InitMetadataForOpus(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_opus()
+      ->set_output_gain(kInvalidOutputGain);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(std::get<OpusDecoderConfig>(
+                output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+                .output_gain_,
+            kInvalidOutputGain);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidOpusChannelMapping) {
+  // IAMF requires `mapping_family` is fixed. The generator does not validate
+  // OBU requirements.
+  const uint8_t kInvalidMappingFamily = 99;
+  ASSERT_NE(kInvalidMappingFamily, OpusDecoderConfig::kMappingFamily);
+  InitMetadataForOpus(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_opus()
+      ->set_mapping_family(kInvalidMappingFamily);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(std::get<OpusDecoderConfig>(
+                output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+                .mapping_family_,
+            kInvalidMappingFamily);
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidOpusDecoderConfigIsMissing) {
+  InitMetadataForOpus(codec_config_metadata_);
+  ASSERT_EQ(codec_config_metadata_.at(0).codec_config().codec_id(),
+            iamf_tools_cli_proto::CODEC_ID_OPUS);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->clear_decoder_config_opus();
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, GeneratesObuForAac) {
+  InitMetadataForAac(codec_config_metadata_);
+  InitExpectedObuForAac(expected_obus_);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(*output_obus, expected_obus_);
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidWhenDecoderSpecificInfoIsMissing) {
+  InitMetadataForAac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_aac()
+      ->clear_decoder_specific_info();
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, IamfAacFixedFieldsMayBeOmitted) {
+  InitMetadataForAac(codec_config_metadata_);
+  // Several fields are fixed in IAMF. It is OK to omit these from the input
+  // data.
+  auto* metadata_decodec_config_aac = codec_config_metadata_.at(0)
+                                          .mutable_codec_config()
+                                          ->mutable_decoder_config_aac();
+  metadata_decodec_config_aac->clear_decoder_config_descriptor_tag();
+  metadata_decodec_config_aac->clear_object_type_indication();
+  metadata_decodec_config_aac->clear_stream_type();
+  metadata_decodec_config_aac->clear_upstream();
+  auto* decoder_specific_info =
+      metadata_decodec_config_aac->mutable_decoder_specific_info();
+  auto* ga_specific_config =
+      metadata_decodec_config_aac->mutable_ga_specific_config();
+  decoder_specific_info->clear_decoder_specific_info_descriptor_tag();
+  decoder_specific_info->clear_audio_object_type();
+  decoder_specific_info->clear_channel_configuration();
+  ga_specific_config->clear_frame_length_flag();
+  ga_specific_config->clear_depends_on_core_coder();
+  ga_specific_config->clear_extension_flag();
+  InitExpectedObuForAac(expected_obus_);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(*output_obus, expected_obus_);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidAacDecoderConfig) {
+  // IAMF requires several fields in the AAC Decoder Config are fixed. The
+  // generator does not validate OBU requirements.
+  const uint8_t kInvalidDecoderConfigDescriptorTag = 99;
+  ASSERT_NE(kInvalidDecoderConfigDescriptorTag,
+            AacDecoderConfig::kDecoderConfigDescriptorTag);
+  const uint8_t kInvalidObjectTypeIndication = 98;
+  ASSERT_NE(kInvalidObjectTypeIndication,
+            AacDecoderConfig::kObjectTypeIndication);
+  const uint8_t kInvalidStreamType = 97;
+  ASSERT_NE(kInvalidStreamType, AacDecoderConfig::kStreamType);
+  const bool kInvalidUpstream = true;
+  ASSERT_NE(kInvalidUpstream, AacDecoderConfig::kUpstream);
+
+  InitMetadataForAac(codec_config_metadata_);
+
+  auto* decoder_config_aac = codec_config_metadata_.at(0)
+                                 .mutable_codec_config()
+                                 ->mutable_decoder_config_aac();
+  decoder_config_aac->set_decoder_config_descriptor_tag(
+      kInvalidDecoderConfigDescriptorTag);
+  decoder_config_aac->set_object_type_indication(kInvalidObjectTypeIndication);
+  decoder_config_aac->set_stream_type(kInvalidStreamType);
+  decoder_config_aac->set_upstream(kInvalidUpstream);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+  const auto& decoder_config = std::get<AacDecoderConfig>(
+      output_obus->at(kCodecConfigId).codec_config_.decoder_config);
+
+  EXPECT_EQ(decoder_config.decoder_config_descriptor_tag_,
+            kInvalidDecoderConfigDescriptorTag);
+  EXPECT_EQ(decoder_config.object_type_indication_,
+            kInvalidObjectTypeIndication);
+  EXPECT_EQ(decoder_config.stream_type_, kInvalidStreamType);
+  EXPECT_EQ(decoder_config.upstream_, kInvalidUpstream);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidAacAudioSpecificConfig) {
+  // IAMF requires `audio_object_type` is fixed. The generator does
+  // not validate OBU requirements.
+  const uint8_t kInvalidAudioObjectType = 99;
+  ASSERT_NE(kInvalidAudioObjectType, AudioSpecificConfig::kAudioObjectType);
+  const uint8_t kInvalidChannelConfiguration = 98;
+  ASSERT_NE(kInvalidChannelConfiguration,
+            AudioSpecificConfig::kChannelConfiguration);
+  InitMetadataForAac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_aac()
+      ->mutable_decoder_specific_info()
+      ->set_audio_object_type(kInvalidAudioObjectType);
+  InitMetadataForAac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_aac()
+      ->mutable_decoder_specific_info()
+      ->set_channel_configuration(kInvalidChannelConfiguration);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  const auto& audio_specific_config =
+      std::get<AacDecoderConfig>(
+          output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+          .decoder_specific_info_.audio_specific_config;
+  EXPECT_EQ(audio_specific_config.audio_object_type_, kInvalidAudioObjectType);
+  EXPECT_EQ(audio_specific_config.channel_configuration_,
+            kInvalidChannelConfiguration);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidDecoderSpecificInfo) {
+  // IAMF requires one field in the Decoder Specific Config is fixed. The
+  // generator does not validate OBU requirements.
+  const uint8_t kInvalidDecoderSpecificInfoTag = 99;
+  ASSERT_NE(kInvalidDecoderSpecificInfoTag,
+            AacDecoderConfig::DecoderSpecificInfo::kDecoderSpecificInfoTag);
+  InitMetadataForAac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_aac()
+      ->mutable_decoder_specific_info()
+      ->set_decoder_specific_info_descriptor_tag(
+          kInvalidDecoderSpecificInfoTag);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(std::get<AacDecoderConfig>(
+                output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+                .decoder_specific_info_.decoder_specific_info_tag,
+            kInvalidDecoderSpecificInfoTag);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidAacGaSpecificConfig) {
+  // IAMF requires several fields in the GA specific config are fixed. The
+  // generator does not validate OBU requirements.
+  const bool kInvalidFrameLengthFlag = true;
+  ASSERT_NE(kInvalidFrameLengthFlag,
+            AudioSpecificConfig::GaSpecificConfig::kFrameLengthFlag);
+  const bool kDependsOnCoreCoder = true;
+  ASSERT_NE(kDependsOnCoreCoder,
+            AudioSpecificConfig::GaSpecificConfig::kDependsOnCoreCoder);
+  const bool kExtensionFlag = true;
+  ASSERT_NE(kDependsOnCoreCoder,
+            AudioSpecificConfig::GaSpecificConfig::kExtensionFlag);
+  InitMetadataForAac(codec_config_metadata_);
+  auto* ga_specific_config = codec_config_metadata_.at(0)
+                                 .mutable_codec_config()
+                                 ->mutable_decoder_config_aac()
+                                 ->mutable_ga_specific_config();
+  ga_specific_config->set_frame_length_flag(kInvalidFrameLengthFlag);
+  ga_specific_config->set_depends_on_core_coder(kDependsOnCoreCoder);
+  ga_specific_config->set_extension_flag(kExtensionFlag);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+  const auto& generated_ga_specific_config =
+      std::get<AacDecoderConfig>(
+          output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+          .decoder_specific_info_.audio_specific_config.ga_specific_config_;
+
+  EXPECT_EQ(generated_ga_specific_config.frame_length_flag,
+            kInvalidFrameLengthFlag);
+  EXPECT_EQ(generated_ga_specific_config.depends_on_core_coder,
+            kDependsOnCoreCoder);
+  EXPECT_EQ(generated_ga_specific_config.extension_flag, kExtensionFlag);
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidUnknownSamplingFrequencyIndex) {
+  InitMetadataForAac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_aac()
+      ->mutable_decoder_specific_info()
+      ->set_sample_frequency_index(
+          iamf_tools_cli_proto::AAC_SAMPLE_FREQUENCY_INDEX_INVALID);
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, ConfiguresAacWithExplicitSamplingFrequency) {
+  InitMetadataForAac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_aac()
+      ->mutable_decoder_specific_info()
+      ->set_sample_frequency_index(
+          iamf_tools_cli_proto::AAC_SAMPLE_FREQUENCY_INDEX_ESCAPE_VALUE);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_aac()
+      ->mutable_decoder_specific_info()
+      ->set_sampling_frequency(9876);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  const auto& audio_specific_config =
+      std::get<AacDecoderConfig>(
+          output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+          .decoder_specific_info_.audio_specific_config;
+  EXPECT_EQ(audio_specific_config.sample_frequency_index_,
+            AudioSpecificConfig::kSampleFrequencyIndexEscapeValue);
+  EXPECT_EQ(audio_specific_config.sampling_frequency_, 9876);
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidAacDecoderConfigIsMissing) {
+  InitMetadataForAac(codec_config_metadata_);
+  ASSERT_EQ(codec_config_metadata_.at(0).codec_config().codec_id(),
+            iamf_tools_cli_proto::CODEC_ID_AAC_LC);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->clear_decoder_config_aac();
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, GeneratesObuForFlac) {
+  InitMetadataForFlac(codec_config_metadata_);
+  InitExpectedObuForFlac(expected_obus_);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(*output_obus, expected_obus_);
+}
+
+TEST_F(CodecConfigGeneratorTest, IamfFlacFixedFieldsMayBeOmitted) {
+  InitMetadataForFlac(codec_config_metadata_);
+  // Some fields are fixed in IAMF. It is OK to omit these from the input data.
+  auto* stream_info = codec_config_metadata_.at(0)
+                          .mutable_codec_config()
+                          ->mutable_decoder_config_flac()
+                          ->mutable_metadata_blocks(0);
+  stream_info->mutable_stream_info()->clear_minimum_frame_size();
+  stream_info->mutable_stream_info()->clear_maximum_frame_size();
+  stream_info->mutable_stream_info()->clear_number_of_channels();
+  stream_info->mutable_stream_info()->clear_md5_signature();
+  InitExpectedObuForFlac(expected_obus_);
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  EXPECT_EQ(*output_obus, expected_obus_);
+}
+
+TEST_F(CodecConfigGeneratorTest, ObeysInvalidFlacStreamInfo) {
+  // IAMF requires several fields in the Stream Info block are fixed. The
+  // generator does not validate OBU requirements.
+  const uint32_t kInvalidMinimumFrameSize = 99;
+  ASSERT_NE(kInvalidMinimumFrameSize,
+            FlacMetaBlockStreamInfo::kMinimumFrameSize);
+  const uint32_t kInvalidMaximumFrameSize = 98;
+  ASSERT_NE(kInvalidMaximumFrameSize,
+            FlacMetaBlockStreamInfo::kMaximumFrameSize);
+  const uint8_t kInvalidNumberOfChannels = 97;
+  ASSERT_NE(kInvalidNumberOfChannels,
+            FlacMetaBlockStreamInfo::kNumberOfChannels);
+  const std::array<uint8_t, 16> kInvalidMd5Signature = {1};
+  ASSERT_NE(kInvalidMd5Signature, FlacMetaBlockStreamInfo::kMd5Signature);
+  InitMetadataForFlac(codec_config_metadata_);
+  auto* stream_info_metadata = codec_config_metadata_.at(0)
+                                   .mutable_codec_config()
+                                   ->mutable_decoder_config_flac()
+                                   ->mutable_metadata_blocks(0)
+                                   ->mutable_stream_info();
+  stream_info_metadata->set_minimum_frame_size(kInvalidMinimumFrameSize);
+  stream_info_metadata->set_maximum_frame_size(kInvalidMaximumFrameSize);
+  stream_info_metadata->set_number_of_channels(kInvalidNumberOfChannels);
+  stream_info_metadata->set_md5_signature(kInvalidMd5Signature.begin(),
+                                          kInvalidMd5Signature.size());
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  const auto& stream_info = std::get<FlacMetaBlockStreamInfo>(
+      std::get<FlacDecoderConfig>(
+          output_obus->at(kCodecConfigId).codec_config_.decoder_config)
+          .metadata_blocks_[0]
+          .payload);
+  EXPECT_EQ(stream_info.minimum_frame_size, kInvalidMinimumFrameSize);
+  EXPECT_EQ(stream_info.maximum_frame_size, kInvalidMaximumFrameSize);
+  EXPECT_EQ(stream_info.number_of_channels, kInvalidNumberOfChannels);
+  EXPECT_EQ(stream_info.md5_signature, kInvalidMd5Signature);
+}
+
+TEST_F(CodecConfigGeneratorTest, ConfiguresFlacWithExtraBlocks) {
+  InitMetadataForFlac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_flac()
+      ->mutable_metadata_blocks(0)
+      ->mutable_header()
+      ->set_last_metadata_block_flag(false);
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        header: {
+          last_metadata_block_flag: true
+          block_type: FLAC_BLOCK_TYPE_PICTURE
+          metadata_data_block_length: 3
+        }
+        generic_block: "abc"
+      )pb",
+      codec_config_metadata_.at(0)
+          .mutable_codec_config()
+          ->mutable_decoder_config_flac()
+          ->add_metadata_blocks()));
+  const auto kExpectedPictureBlock = (FlacMetadataBlock){
+      .header = {.last_metadata_block_flag = true,
+                 .block_type = FlacMetaBlockHeader::kFlacPicture,
+                 .metadata_data_block_length = 3},
+      .payload = std::vector<uint8_t>({'a', 'b', 'c'})};
+
+  const auto output_obus = InitAndGenerate();
+  ASSERT_TRUE(output_obus.ok());
+
+  const auto& decoder_config = std::get<FlacDecoderConfig>(
+      output_obus->at(kCodecConfigId).codec_config_.decoder_config);
+  ASSERT_EQ(decoder_config.metadata_blocks_.size(), 2);
+
+  EXPECT_EQ(decoder_config.metadata_blocks_[0].header.block_type,
+            FlacMetaBlockHeader::kFlacStreamInfo);
+  EXPECT_EQ(decoder_config.metadata_blocks_[0].header.last_metadata_block_flag,
+            false);
+  EXPECT_EQ(decoder_config.metadata_blocks_[1], kExpectedPictureBlock);
+}
+
+TEST_F(CodecConfigGeneratorTest, FailsWhenMd5SignatureIsNotSixteenBytes) {
+  InitMetadataForFlac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_flac()
+      ->mutable_metadata_blocks(0)
+      ->mutable_stream_info()
+      ->mutable_md5_signature()
+      ->assign("0");
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidUnknownBlockType) {
+  InitMetadataForFlac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_flac()
+      ->mutable_metadata_blocks(0)
+      ->mutable_header()
+      ->set_last_metadata_block_flag(false);
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        header: {
+          last_metadata_block_flag: true
+          block_type: FLAC_BLOCK_TYPE_INVALID
+          metadata_data_block_length: 0
+        }
+      )pb",
+      codec_config_metadata_.at(0)
+          .mutable_codec_config()
+          ->mutable_decoder_config_flac()
+          ->add_metadata_blocks()));
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidMissingGenericBlock) {
+  InitMetadataForFlac(codec_config_metadata_);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_flac()
+      ->mutable_metadata_blocks(0)
+      ->mutable_header()
+      ->set_last_metadata_block_flag(false);
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        header: {
+          last_metadata_block_flag: true
+          block_type: FLAC_BLOCK_TYPE_PICTURE
+          metadata_data_block_length: 3
+        }
+      )pb",
+      codec_config_metadata_.at(0)
+          .mutable_codec_config()
+          ->mutable_decoder_config_flac()
+          ->add_metadata_blocks()));
+  ASSERT_FALSE(codec_config_metadata_.at(0)
+                   .codec_config()
+                   .decoder_config_flac()
+                   .metadata_blocks(1)
+                   .has_generic_block());
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidFlacDecoderConfigIsMissing) {
+  InitMetadataForFlac(codec_config_metadata_);
+  ASSERT_EQ(codec_config_metadata_.at(0).codec_config().codec_id(),
+            iamf_tools_cli_proto::CODEC_ID_FLAC);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->clear_decoder_config_flac();
+
+  EXPECT_FALSE(InitAndGenerate().ok());
+}
+
+TEST_F(CodecConfigGeneratorTest, InvalidMissingStreamInfoBlock) {
+  InitMetadataForFlac(codec_config_metadata_);
+  ASSERT_EQ(codec_config_metadata_.at(0)
+                .codec_config()
+                .decoder_config_flac()
+                .metadata_blocks(0)
+                .header()
+                .block_type(),
+            iamf_tools_cli_proto::FLAC_BLOCK_TYPE_STREAMINFO);
+  codec_config_metadata_.at(0)
+      .mutable_codec_config()
+      ->mutable_decoder_config_flac()
+      ->mutable_metadata_blocks(0)
+      ->clear_stream_info();
+
+  EXPECT_FALSE(InitAndGenerate().ok());
 }
 
 }  // namespace

--- a/iamf/cli/tests/flac_encoder_test.cc
+++ b/iamf/cli/tests/flac_encoder_test.cc
@@ -55,18 +55,11 @@ class FlacEncoderTest : public EncoderTestBase, public testing::Test {
       {{.header = {.last_metadata_block_flag = true,
                    .block_type = FlacMetaBlockHeader::kFlacStreamInfo,
                    .metadata_data_block_length = 34},
-        .payload = FlacMetaBlockStreamInfo{
-            .minimum_block_size = 16,
-            .maximum_block_size = 16,
-            .minimum_frame_size = 0,
-            .maximum_frame_size = 0,
-            .sample_rate = 48000,
-            .number_of_channels = 0,
-            .bits_per_sample = 31,
-            .total_samples_in_stream = 16,
-            .md5_signature = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                              0x00}}}}};
+        .payload = FlacMetaBlockStreamInfo{.minimum_block_size = 16,
+                                           .maximum_block_size = 16,
+                                           .sample_rate = 48000,
+                                           .bits_per_sample = 31,
+                                           .total_samples_in_stream = 16}}}};
   iamf_tools_cli_proto::FlacEncoderMetadata flac_encoder_metadata_ = {};
 };  // namespace iamf_tools
 

--- a/iamf/cli/tests/ia_sequence_header_generator_test.cc
+++ b/iamf/cli/tests/ia_sequence_header_generator_test.cc
@@ -11,6 +11,7 @@
  */
 #include "iamf/cli/ia_sequence_header_generator.h"
 
+#include <cstdint>
 #include <optional>
 
 #include "absl/status/status.h"
@@ -54,6 +55,14 @@ class IaSequenceHeaderGeneratorTest : public testing::Test {
 };
 
 TEST_F(IaSequenceHeaderGeneratorTest, DefaultSimpleProfile) {
+  expected_obu_.emplace(ObuHeader(), IASequenceHeaderObu::kIaCode,
+                        ProfileVersion::kIamfSimpleProfile,
+                        ProfileVersion::kIamfSimpleProfile);
+  InitAndTestGenerate();
+}
+
+TEST_F(IaSequenceHeaderGeneratorTest, IaCodeMayBeOmitted) {
+  ia_sequence_header_metadata_.clear_ia_code();
   expected_obu_.emplace(ObuHeader(), IASequenceHeaderObu::kIaCode,
                         ProfileVersion::kIamfSimpleProfile,
                         ProfileVersion::kIamfSimpleProfile);
@@ -108,9 +117,12 @@ TEST_F(IaSequenceHeaderGeneratorTest, BaseProfile) {
 TEST_F(IaSequenceHeaderGeneratorTest, ObeysInvalidIaCode) {
   // IAMF requires `ia_code == IASequenceHeaderObu::kIaCode`. But the generator
   // does not validate OBU requirements.
-  ia_sequence_header_metadata_.set_ia_code(0);
+  const uint32_t kInvalidIaCode = 0;
+  ASSERT_NE(kInvalidIaCode, IASequenceHeaderObu::kIaCode);
+  ia_sequence_header_metadata_.set_ia_code(kInvalidIaCode);
 
-  expected_obu_.emplace(ObuHeader(), 0, ProfileVersion::kIamfSimpleProfile,
+  expected_obu_.emplace(ObuHeader(), kInvalidIaCode,
+                        ProfileVersion::kIamfSimpleProfile,
                         ProfileVersion::kIamfSimpleProfile);
   InitAndTestGenerate();
 }

--- a/iamf/cli/tests/iamf_components_test.cc
+++ b/iamf/cli/tests/iamf_components_test.cc
@@ -12,7 +12,9 @@
 
 #include "iamf/cli/iamf_components.h"
 
+#include <cstdint>
 #include <filesystem>
+#include <optional>
 
 #include "gtest/gtest.h"
 #include "iamf/cli/proto/test_vector_metadata.pb.h"
@@ -23,7 +25,9 @@ namespace iamf_tools {
 namespace {
 
 TEST(IamfComponentsTest, CreateMixPresentationFinalizerReturnsNonNull) {
-  EXPECT_NE(CreateMixPresentationFinalizer({}, /*file_name_prefix=*/""),
+  EXPECT_NE(CreateMixPresentationFinalizer(
+                {}, /*file_name_prefix=*/"",
+                /*output_wav_file_bit_depth_override=*/std::nullopt),
             nullptr);
 }
 
@@ -56,6 +60,13 @@ TEST(IamfComponentsTest, CanBeConfiguredWithFixedSizeLebGenerator) {
   for (auto& obu_sequencer : obu_sequencers) {
     EXPECT_NE(obu_sequencer, nullptr);
   }
+}
+
+TEST(IamfComponentsTest, CanBeConfiguredWithOutputWavFileBitDepthOverride) {
+  const uint8_t kOutputWavFileBitDepthOverride = 16;
+  EXPECT_NE(
+      CreateMixPresentationFinalizer({}, "", kOutputWavFileBitDepthOverride),
+      nullptr);
 }
 
 TEST(IamfComponentsTest, ReturnsEmptyListWhenLebGeneratorIsInvalid) {

--- a/iamf/cli/tests/opus_encoder_test.cc
+++ b/iamf/cli/tests/opus_encoder_test.cc
@@ -52,12 +52,8 @@ class OpusEncoderTest : public EncoderTestBase, public testing::Test {
                                              codec_config, num_channels_);
   }
 
-  OpusDecoderConfig opus_decoder_config_ = {.version_ = 1,
-                                            .output_channel_count_ = 2,
-                                            .pre_skip_ = 312,
-                                            .input_sample_rate_ = 48000,
-                                            .output_gain_ = 0,
-                                            .mapping_family_ = 0};
+  OpusDecoderConfig opus_decoder_config_ = {
+      .version_ = 1, .pre_skip_ = 312, .input_sample_rate_ = 48000};
   iamf_tools_cli_proto::OpusEncoderMetadata opus_encoder_metadata_ = {};
 };  // namespace iamf_tools
 

--- a/iamf/cli/tests/wav_sample_provider_test.cc
+++ b/iamf/cli/tests/wav_sample_provider_test.cc
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2024, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#include "iamf/cli/wav_sample_provider.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+// Placeholder for get runfiles header.
+#include "absl/container/flat_hash_map.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "iamf/cli/audio_element_with_data.h"
+#include "iamf/cli/demixing_module.h"
+#include "iamf/cli/proto/user_metadata.pb.h"
+#include "iamf/cli/tests/cli_test_utils.h"
+#include "iamf/codec_config.h"
+#include "iamf/ia.h"
+#include "src/google/protobuf/text_format.h"
+
+namespace iamf_tools {
+namespace {
+
+static constexpr DecodedUleb128 kAudioElementId = 300;
+static constexpr DecodedUleb128 kCodecConfigId = 200;
+static constexpr uint32_t kSampleRate = 48000;
+
+void InitializeTestData(
+    const uint32_t sample_rate,
+    iamf_tools_cli_proto::UserMetadata& user_metadata,
+    absl::flat_hash_map<DecodedUleb128, AudioElementWithData>& audio_elements) {
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        wav_filename: "stereo_8_samples_48khz_s16le.wav"
+        samples_to_trim_at_end: 0
+        samples_to_trim_at_start: 0
+        audio_element_id: 300
+        channel_ids: [ 0, 1 ]
+        channel_labels: [ "L2", "R2" ]
+      )pb",
+      user_metadata.add_audio_frame_metadata()));
+
+  static absl::flat_hash_map<uint32_t, CodecConfigObu> codec_config_obus;
+  codec_config_obus.clear();
+  AddLpcmCodecConfigWithIdAndSampleRate(kCodecConfigId, sample_rate,
+                                        codec_config_obus);
+  const std::vector<DecodedUleb128> kSubstreamIds = {0};
+  AddScalableAudioElementWithSubstreamIds(kAudioElementId, kCodecConfigId,
+                                          kSubstreamIds, codec_config_obus,
+                                          audio_elements);
+}
+
+std::filesystem::path GetInputWavDir() {
+  static const auto input_wav_dir =
+      std::filesystem::current_path() / std::string("iamf/cli/testdata");
+  return input_wav_dir;
+}
+
+TEST(WavSampleProviderTest, InitializeSucceeds) {
+  iamf_tools_cli_proto::UserMetadata user_metadata;
+  absl::flat_hash_map<DecodedUleb128, AudioElementWithData> audio_elements;
+  InitializeTestData(kSampleRate, user_metadata, audio_elements);
+
+  WavSampleProvider wav_sample_provider(user_metadata.audio_frame_metadata());
+  EXPECT_TRUE(
+      wav_sample_provider.Initialize(GetInputWavDir(), audio_elements).ok());
+}
+
+TEST(WavSampleProviderTest, MismatchingChannelIdsAndLabels) {
+  iamf_tools_cli_proto::UserMetadata user_metadata;
+  absl::flat_hash_map<DecodedUleb128, AudioElementWithData> audio_elements;
+  InitializeTestData(kSampleRate, user_metadata, audio_elements);
+
+  // Add one extra channel label, which does not have a corresponding
+  // channel ID, causing the `Initialize()` to fail.
+  user_metadata.mutable_audio_frame_metadata(0)->add_channel_labels("C");
+
+  WavSampleProvider wav_sample_provider(user_metadata.audio_frame_metadata());
+  EXPECT_FALSE(
+      wav_sample_provider.Initialize(GetInputWavDir(), audio_elements).ok());
+}
+
+TEST(WavSampleProviderTest, BitDepthLowerThanFile) {
+  iamf_tools_cli_proto::UserMetadata user_metadata;
+  absl::flat_hash_map<DecodedUleb128, AudioElementWithData> audio_elements;
+  InitializeTestData(kSampleRate, user_metadata, audio_elements);
+
+  // Try to load a 24-bit WAV file with a codec config whose bit depth is 16.
+  // The `Initialize()` would refuse to lower the bit depth and fail.
+  user_metadata.mutable_audio_frame_metadata(0)->set_wav_filename(
+      "stereo_8_samples_48khz_s24le.wav");
+
+  WavSampleProvider wav_sample_provider(user_metadata.audio_frame_metadata());
+  EXPECT_FALSE(
+      wav_sample_provider.Initialize(GetInputWavDir(), audio_elements).ok());
+}
+
+TEST(WavSampleProviderTest, MismatchingSampleRates) {
+  iamf_tools_cli_proto::UserMetadata user_metadata;
+  absl::flat_hash_map<DecodedUleb128, AudioElementWithData> audio_elements;
+
+  // Set the sample rate of the codec config to a different one than the WAV
+  // file, causing the `Initialize()` to fail.
+  const uint32_t kWrongSampleRate = 16000;
+  InitializeTestData(kWrongSampleRate, user_metadata, audio_elements);
+
+  WavSampleProvider wav_sample_provider(user_metadata.audio_frame_metadata());
+  EXPECT_FALSE(
+      wav_sample_provider.Initialize(GetInputWavDir(), audio_elements).ok());
+}
+
+TEST(WavSampleProviderTest, ReadFrameSucceeds) {
+  iamf_tools_cli_proto::UserMetadata user_metadata;
+  absl::flat_hash_map<DecodedUleb128, AudioElementWithData> audio_elements;
+  InitializeTestData(kSampleRate, user_metadata, audio_elements);
+
+  WavSampleProvider wav_sample_provider(user_metadata.audio_frame_metadata());
+  ASSERT_TRUE(
+      wav_sample_provider.Initialize(GetInputWavDir(), audio_elements).ok());
+
+  LabelSamplesMap labeled_samples;
+  EXPECT_TRUE(
+      wav_sample_provider.ReadFrames(kAudioElementId, labeled_samples).ok());
+
+  // Validate samples read from the WAV file.
+  const std::vector<int32_t> expected_samples_l2 = {
+      1 << 16, 2 << 16, 3 << 16, 4 << 16, 5 << 16, 6 << 16, 7 << 16, 8 << 16};
+  const std::vector<int32_t> expected_samples_r2 = {
+      65535 << 16, 65534 << 16, 65533 << 16, 65532 << 16,
+      65531 << 16, 65530 << 16, 65529 << 16, 65528 << 16};
+  EXPECT_THAT(labeled_samples["L2"], testing::Eq(expected_samples_l2));
+  EXPECT_THAT(labeled_samples["R2"], testing::Eq(expected_samples_r2));
+}
+
+TEST(WavSampleProviderTest, ReadFrameFailsWithWrongAudioElementId) {
+  iamf_tools_cli_proto::UserMetadata user_metadata;
+  absl::flat_hash_map<DecodedUleb128, AudioElementWithData> audio_elements;
+  InitializeTestData(kSampleRate, user_metadata, audio_elements);
+
+  WavSampleProvider wav_sample_provider(user_metadata.audio_frame_metadata());
+  ASSERT_TRUE(
+      wav_sample_provider.Initialize(GetInputWavDir(), audio_elements).ok());
+
+  // Try to read frames using a wrong Audio Element ID.
+  const auto kWrongAudioElementId = kAudioElementId + 99;
+  LabelSamplesMap labeled_samples;
+  EXPECT_FALSE(
+      wav_sample_provider.ReadFrames(kWrongAudioElementId, labeled_samples)
+          .ok());
+}
+
+TEST(WavSampleProviderTest, ReadFrameFailsWithoutCallingInitialize) {
+  iamf_tools_cli_proto::UserMetadata user_metadata;
+  absl::flat_hash_map<DecodedUleb128, AudioElementWithData> audio_elements;
+  InitializeTestData(kSampleRate, user_metadata, audio_elements);
+
+  WavSampleProvider wav_sample_provider(user_metadata.audio_frame_metadata());
+
+  // Miss the following call to `Initialize()`:
+  // ASSERT_TRUE(
+  //     wav_sample_provider.Initialize(GetInputWavDir(), audio_elements).ok());
+
+  LabelSamplesMap labeled_samples;
+  EXPECT_FALSE(
+      wav_sample_provider.ReadFrames(kAudioElementId, labeled_samples).ok());
+}
+
+}  // namespace
+}  // namespace iamf_tools

--- a/iamf/cli/wav_sample_provider.cc
+++ b/iamf/cli/wav_sample_provider.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+#include "iamf/cli/wav_sample_provider.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "iamf/cli/audio_element_with_data.h"
+#include "iamf/cli/demixing_module.h"
+#include "iamf/cli/wav_reader.h"
+#include "iamf/ia.h"
+
+namespace iamf_tools {
+
+absl::Status WavSampleProvider::Initialize(
+    const std::string& input_wav_directory,
+    const absl::flat_hash_map<DecodedUleb128, AudioElementWithData>&
+        audio_elements) {
+  for (const auto& [audio_element_id, audio_frame_metadata] :
+       audio_frame_metadata_) {
+    if (audio_frame_metadata.channel_ids_size() !=
+        audio_frame_metadata.channel_labels_size()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("#channel IDs and #channel labels differ: (",
+                       audio_frame_metadata.channel_ids_size(), " vs ",
+                       audio_frame_metadata.channel_labels_size(), ")"));
+    }
+
+    const auto audio_element_iter = audio_elements.find(audio_element_id);
+    if (audio_element_iter == audio_elements.end()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("No Audio Element found for ID= ", audio_element_id));
+    }
+    const auto& codec_config = *audio_element_iter->second.codec_config;
+    const auto& wav_filename = std::filesystem::path(input_wav_directory) /
+                               audio_frame_metadata.wav_filename();
+
+    auto [wav_reader_iter, emplaced] = wav_readers_.emplace(
+        audio_element_id,
+        std::make_unique<WavReader>(
+            wav_filename.c_str(),
+            static_cast<size_t>(codec_config.GetNumSamplesPerFrame())));
+    const auto& wav_reader = *wav_reader_iter->second;
+
+    const int encoder_input_pcm_bit_depth =
+        static_cast<int>(codec_config.GetBitDepthToMeasureLoudness());
+    if (wav_reader.bit_depth() > encoder_input_pcm_bit_depth) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Refusing to lower bit-depth of WAV (", wav_filename.string(),
+          ") with bit_depth= ", wav_reader.bit_depth(),
+          " to bit_depth=", encoder_input_pcm_bit_depth));
+    }
+
+    const uint32_t encoder_input_sample_rate =
+        codec_config.GetInputSampleRate();
+    if (wav_reader.sample_rate_hz() != encoder_input_sample_rate) {
+      // TODO(b/277899855): Support resampling the input wav file to match the
+      //                    input sample rate.
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Sample rate read from ", wav_filename.string(),
+          " inconsistent with the user metadata: (",
+          wav_reader.sample_rate_hz(), " vs ", encoder_input_sample_rate, ")"));
+    }
+
+    const uint32_t decoder_output_sample_rate =
+        codec_config.GetOutputSampleRate();
+    if (encoder_input_sample_rate != decoder_output_sample_rate) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Input and output sample rates differ: (", encoder_input_sample_rate,
+          " vs ", decoder_output_sample_rate, ")"));
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status WavSampleProvider::ReadFrames(
+    const DecodedUleb128 audio_element_id, LabelSamplesMap& labeled_samples) {
+  auto wav_reader_iter = wav_readers_.find(audio_element_id);
+  if (wav_reader_iter == wav_readers_.end()) {
+    LOG(ERROR) << "No WAV reader found for Audio Element ID= "
+               << audio_element_id;
+    return absl::InvalidArgumentError("");
+  }
+  auto& wav_reader = *wav_reader_iter->second;
+  const size_t samples_read = wav_reader.ReadFrame();
+  LOG_FIRST_N(INFO, 1) << samples_read << " samples read";
+
+  // Note if the WAV reader is found for the Audio Element ID, then it's
+  // guaranteed to have a corresponding audio frame metadata (otherwise the
+  // `Initialize()` would have failed).
+  const auto& audio_frame_metadata = audio_frame_metadata_.at(audio_element_id);
+  const size_t num_time_ticks = samples_read / wav_reader.num_channels();
+  const auto& channel_ids = audio_frame_metadata.channel_ids();
+  const auto& channel_labels = audio_frame_metadata.channel_labels();
+  labeled_samples.clear();
+  for (int c = 0; c < channel_labels.size(); ++c) {
+    auto& samples = labeled_samples[channel_labels[c]];
+    samples.resize(num_time_ticks);
+    for (int t = 0; t < num_time_ticks; ++t) {
+      samples[t] = wav_reader.buffers_[t][channel_ids[c]];
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+}  // namespace iamf_tools

--- a/iamf/cli/wav_sample_provider.h
+++ b/iamf/cli/wav_sample_provider.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+#ifndef CLI_WAV_SAMPLE_PROVIDER_H_
+#define CLI_WAV_SAMPLE_PROVIDER_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "iamf/cli/audio_element_with_data.h"
+#include "iamf/cli/demixing_module.h"
+#include "iamf/cli/proto/audio_frame.pb.h"
+#include "iamf/cli/wav_reader.h"
+#include "iamf/ia.h"
+#include "src/google/protobuf/repeated_ptr_field.h"
+
+namespace iamf_tools {
+
+class WavSampleProvider {
+ public:
+  /*\!brief Constructor.
+   *
+   * \param audio_frame_metadata Input audio frame metadata.
+   */
+  WavSampleProvider(
+      const ::google::protobuf::RepeatedPtrField<
+          iamf_tools_cli_proto::AudioFrameObuMetadata>& audio_frame_metadata) {
+    for (const auto& audio_frame_obu_metadata : audio_frame_metadata) {
+      audio_frame_metadata_[audio_frame_obu_metadata.audio_element_id()] =
+          audio_frame_obu_metadata;
+    }
+  }
+
+  /*\!brief Initializes WAV readers that provide samples for the audio frames.
+   *
+   * \param input_wav_directory Directory containing the input WAV files.
+   * \param audio_elements Input Audio Element OBUs with data.
+   * \return `absl::OkStatus()` on success. A specific status on failure.
+   */
+  absl::Status Initialize(
+      const std::string& input_wav_directory,
+      const absl::flat_hash_map<DecodedUleb128, AudioElementWithData>&
+          audio_elements);
+
+  /*\!brief Read frames from WAV files corresponding to an Audio Element.
+   *
+   * \param audio_element_id ID of the Audio Element whose corresponding frames
+   *      are to be read from WAV files.
+   * \param labeled_samples Output samples organized by their channel labels.
+   * \return `absl::OkStatus()` on success. A specific status on failure.
+   */
+  absl::Status ReadFrames(DecodedUleb128 audio_element_id,
+                          LabelSamplesMap& labeled_samples);
+
+ private:
+  // Mapping from Audio Element ID to `WavReader`.
+  absl::flat_hash_map<DecodedUleb128, std::unique_ptr<WavReader>> wav_readers_;
+
+  // Mapping from Audio Element ID to audio frame metadata.
+  absl::flat_hash_map<DecodedUleb128,
+                      iamf_tools_cli_proto::AudioFrameObuMetadata>
+      audio_frame_metadata_;
+};
+
+}  // namespace iamf_tools
+
+#endif  // CLI_WAV_SAMPLE_PROVIDER_H_

--- a/iamf/codec_config.h
+++ b/iamf/codec_config.h
@@ -69,7 +69,7 @@ class CodecConfigObu : public ObuBase {
   CodecConfigObu(CodecConfigObu&& other) = default;
 
   /*!\brief Destructor. */
-  ~CodecConfigObu() override {}
+  ~CodecConfigObu() override = default;
 
   friend bool operator==(const CodecConfigObu& lhs,
                          const CodecConfigObu& rhs) = default;

--- a/iamf/demixing_info_param_data.h
+++ b/iamf/demixing_info_param_data.h
@@ -91,7 +91,7 @@ struct DemixingInfoParameterData {
 struct DefaultDemixingInfoParameterData : public DemixingInfoParameterData {
   /*!\brief Overridden destructor.
    */
-  ~DefaultDemixingInfoParameterData() override {}
+  ~DefaultDemixingInfoParameterData() override = default;
 
   bool friend operator==(const DefaultDemixingInfoParameterData& a,
                          const DefaultDemixingInfoParameterData& b) = default;

--- a/iamf/flac_decoder_config.h
+++ b/iamf/flac_decoder_config.h
@@ -23,6 +23,13 @@
 namespace iamf_tools {
 
 struct FlacMetaBlockStreamInfo {
+  // IAMF requires some fields to have fixed values.
+  static constexpr uint32_t kMinimumFrameSize = 0;
+  static constexpr uint32_t kMaximumFrameSize = 0;
+  // In IAMF the field is fixed to `1`, but ignored. The actual number of
+  // channels is determined on a per-substream basis based on the audio element.
+  static constexpr uint8_t kNumberOfChannels = 1;
+  static constexpr std::array<uint8_t, 16> kMd5Signature = {0};
   // Constants for restrictions from the FLAC documentation.
   static constexpr uint32_t kMinSampleRate = 1;
   static constexpr uint32_t kMaxSampleRate = 655350;
@@ -37,13 +44,13 @@ struct FlacMetaBlockStreamInfo {
 
   uint16_t minimum_block_size;
   uint16_t maximum_block_size;
-  uint32_t minimum_frame_size;       // 24 bits.
-  uint32_t maximum_frame_size;       // 24 bits.
-  uint32_t sample_rate;              // 20 bits.
-  uint8_t number_of_channels;        // 3 bits.
-  uint8_t bits_per_sample;           // 5 bits.
-  uint64_t total_samples_in_stream;  // 36 bits.
-  std::array<uint8_t, 16> md5_signature;
+  uint32_t minimum_frame_size = kMinimumFrameSize;  // 24 bits.
+  uint32_t maximum_frame_size = kMaximumFrameSize;  // 24 bits.
+  uint32_t sample_rate;                             // 20 bits.
+  uint8_t number_of_channels = kNumberOfChannels;   // 3 bits.
+  uint8_t bits_per_sample;                          // 5 bits.
+  uint64_t total_samples_in_stream;                 // 36 bits.
+  std::array<uint8_t, 16> md5_signature = kMd5Signature;
 };
 
 /*!\brief The header portion of a metadata block described in the FLAC spec. */

--- a/iamf/ia.h
+++ b/iamf/ia.h
@@ -22,24 +22,11 @@ enum class ProfileVersion : uint8_t {
   kIamfBaseProfile = 1,
 };
 
-/*!\brief The maximum length of an IAMF string in bytes.
- *
- * The spec limits the length of a string to 128 bytes including the
- * null terminator ('\0').
- */
-inline constexpr int kIamfMaxStringSize = 128;
-
 /*!\brief A decoded `leb128` in IAMF.  */
 typedef uint32_t DecodedUleb128;
 
 /*!\brief A decoded `sleb128` in IAMF.  */
 typedef int32_t DecodedSleb128;
-
-/*!\brief A `string` as defined by the IAMF spec.
- *
- * The IAMF spec requires this is null terminated and at most 128 bytes.
- */
-typedef char IamfString[kIamfMaxStringSize];
 
 // For propagating errors when calling a function. Beware that defining
 // `NO_CHECK_ERROR` is not thoroughly tested and may result in unexpected

--- a/iamf/ia_sequence_header.h
+++ b/iamf/ia_sequence_header.h
@@ -44,9 +44,7 @@ class IASequenceHeaderObu : public ObuBase {
   IASequenceHeaderObu(IASequenceHeaderObu&& other) = default;
 
   /*!\brief Destructor. */
-  ~IASequenceHeaderObu() override {
-    // There is no memory to clean up for an IA Sequence Header OBU.
-  }
+  ~IASequenceHeaderObu() override = default;
 
   friend bool operator==(const IASequenceHeaderObu& lhs,
                          const IASequenceHeaderObu& rhs) = default;

--- a/iamf/mix_presentation.h
+++ b/iamf/mix_presentation.h
@@ -344,7 +344,7 @@ class MixPresentationObu : public ObuBase {
   MixPresentationObu(const MixPresentationObu& other) = default;
 
   /*!\brief Destructor. */
-  ~MixPresentationObu() override;
+  ~MixPresentationObu() override = default;
 
   friend bool operator==(const MixPresentationObu& lhs,
                          const MixPresentationObu& rhs) = default;

--- a/iamf/obu_util.h
+++ b/iamf/obu_util.h
@@ -18,6 +18,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "iamf/ia.h"
 
 namespace iamf_tools {
@@ -182,6 +183,25 @@ absl::Status LookupInMap(const absl::flat_hash_map<T, U>& map, T key,
   }
   value = iter->second;
   return absl::OkStatus();
+}
+
+/*\!brief Returns an error if the arguments are not equal.
+ *
+ * \param left First value to compare.
+ * \param right Second value to compare.
+ * \param field_name Field name to insert into the error message.
+ * \return `absl::OkStatus()` if the arguments are equal
+ *     `absl::InvalidArgumentError()` otherwise.
+ */
+template <typename T>
+absl::Status ValidateEqual(const T& left, const T& right,
+                           const std::string& field_name) {
+  if (left == right) {
+    return absl::OkStatus();
+  }
+
+  return absl::InvalidArgumentError(absl::StrCat(
+      "Invalid ", field_name, ". Expected ", left, " == ", right, "."));
 }
 
 }  // namespace iamf_tools

--- a/iamf/opus_decoder_config.cc
+++ b/iamf/opus_decoder_config.cc
@@ -17,6 +17,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "iamf/ia.h"
+#include "iamf/obu_util.h"
 #include "iamf/write_bit_buffer.h"
 
 namespace iamf_tools {
@@ -44,19 +45,15 @@ absl::Status ValidatePayload(const OpusDecoderConfig& decoder_config) {
 
   // Various below fields are fixed. The real value is determined from the Audio
   // Element OBU.
-  if (decoder_config.output_channel_count_ != 2) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid output_channel_count= ",
-                     decoder_config.output_channel_count_));
-  }
-  if (decoder_config.output_gain_ != 0) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Invalid output_gain= ", decoder_config.output_gain_));
-  }
-  if (decoder_config.mapping_family_ != 0) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Invalid mapping_family= ", decoder_config.mapping_family_));
-  }
+  RETURN_IF_NOT_OK(ValidateEqual(decoder_config.output_channel_count_,
+                                 OpusDecoderConfig::kOutputChannelCount,
+                                 "output_channel_count"));
+  RETURN_IF_NOT_OK(ValidateEqual(decoder_config.output_gain_,
+                                 OpusDecoderConfig::kOutputGain,
+                                 "output_gain"));
+  RETURN_IF_NOT_OK(ValidateEqual(decoder_config.mapping_family_,
+                                 OpusDecoderConfig::kMappingFamily,
+                                 "mapping_family"));
 
   return absl::OkStatus();
 }

--- a/iamf/opus_decoder_config.h
+++ b/iamf/opus_decoder_config.h
@@ -22,6 +22,10 @@ namespace iamf_tools {
 /*!\brief The `CodecConfig` `decoder_config` field for Opus.*/
 class OpusDecoderConfig {
  public:
+  static constexpr uint8_t kOutputChannelCount = 2;
+  static constexpr int16_t kOutputGain = 0;
+  static constexpr uint8_t kMappingFamily = 0;
+
   friend bool operator==(const OpusDecoderConfig& lhs,
                          const OpusDecoderConfig& rhs) = default;
 
@@ -71,11 +75,12 @@ class OpusDecoderConfig {
   void Print() const;
 
   uint8_t version_;
-  uint8_t output_channel_count_;  // Must be set to 2. This field is ignored.
+  // Must be set to 2. This field is ignored.
+  uint8_t output_channel_count_ = kOutputChannelCount;
   uint16_t pre_skip_;
   uint32_t input_sample_rate_;
-  int16_t output_gain_;     // Must be 0.
-  uint8_t mapping_family_;  // Must be 0.
+  int16_t output_gain_ = kOutputGain;
+  uint8_t mapping_family_ = kMappingFamily;
 };
 
 }  // namespace iamf_tools

--- a/iamf/param_definitions.h
+++ b/iamf/param_definitions.h
@@ -164,7 +164,7 @@ class MixGainParamDefinition : public ParamDefinition {
 
   /*!\brief Default destructor.
    */
-  ~MixGainParamDefinition() override {}
+  ~MixGainParamDefinition() override = default;
 
   friend bool operator==(const MixGainParamDefinition& lhs,
                          const MixGainParamDefinition& rhs) {
@@ -208,7 +208,7 @@ class DemixingParamDefinition : public ParamDefinition {
 
   /*!\brief Default destructor.
    */
-  ~DemixingParamDefinition() override {}
+  ~DemixingParamDefinition() override = default;
 
   friend bool operator==(const DemixingParamDefinition& lhs,
                          const DemixingParamDefinition& rhs) {
@@ -258,7 +258,7 @@ class ReconGainParamDefinition : public ParamDefinition {
 
   /*!\brief Default destructor.
    */
-  ~ReconGainParamDefinition() override {}
+  ~ReconGainParamDefinition() override = default;
 
   friend bool operator==(const ReconGainParamDefinition& lhs,
                          const ReconGainParamDefinition& rhs) {
@@ -305,7 +305,7 @@ class ExtendedParamDefinition : public ParamDefinition {
 
   /*!\brief Default destructor.
    */
-  ~ExtendedParamDefinition() override {}
+  ~ExtendedParamDefinition() override = default;
 
   friend bool operator==(const ExtendedParamDefinition& lhs,
                          const ExtendedParamDefinition& rhs) {

--- a/iamf/parameter_block.h
+++ b/iamf/parameter_block.h
@@ -196,7 +196,7 @@ class ParameterBlockObu : public ObuBase {
                     PerIdParameterMetadata* metadata);
 
   /*!\brief Destructor. */
-  ~ParameterBlockObu() override {}
+  ~ParameterBlockObu() override = default;
 
   /*!\brief Interpolate the value of a `MixGainParameterData`.
    *

--- a/iamf/read_bit_buffer.cc
+++ b/iamf/read_bit_buffer.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+#include "iamf/read_bit_buffer.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "iamf/cli/leb_generator.h"
+
+namespace iamf_tools {
+
+ReadBitBuffer::ReadBitBuffer(int64_t capacity, std::vector<uint8_t>* source,
+                             const LebGenerator& leb_generator)
+    : leb_generator_(leb_generator), source_(source) {
+  bit_buffer_.reserve(capacity);
+}
+
+// Reads n = `num_bits` bits from the buffer. These are the lower n bits of
+// bit_buffer_. n must be <= 64. The read data is consumed, meaning
+// bit_buffer_offset_ is incremented by n as a side effect of this fxn.
+absl::Status ReadBitBuffer::ReadUnsignedLiteral(uint64_t* data, int num_bits) {
+  return absl::UnimplementedError("Not yet implemented.");
+}
+
+// Loads enough bits from source such that there are at least n =
+// `required_num_bits` in bit_buffer_ after completion. Returns an error if
+// there are not enough bits in source_ to fulfill this request. If source_
+// contains enough data, this function will fill the read buffer completely.
+absl::Status ReadBitBuffer::LoadBits(const int32_t required_num_bits) {
+  return absl::UnimplementedError("Not yet implemented.");
+}
+
+absl::Status ReadBitBuffer::DiscardAllBits() {
+  bit_buffer_offset_ = 0;
+  bit_buffer_.clear();
+  return absl::OkStatus();
+}
+
+}  // namespace iamf_tools

--- a/iamf/read_bit_buffer.h
+++ b/iamf/read_bit_buffer.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#ifndef READ_BIT_BUFFER_H_
+#define READ_BIT_BUFFER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "iamf/cli/leb_generator.h"
+
+namespace iamf_tools {
+
+/*!\brief Holds a buffer and tracks the next bit to be read from. */
+class ReadBitBuffer {
+ public:
+  /*!\brief Constructor.
+   *
+   * \param capacity Capacity of the internal buffer in bytes.
+   * \param source Pointer to the data source from which the read buffer will
+   *     iteratively load data.
+   * \param leb_generator `LebGenerator` to use.
+   */
+  ReadBitBuffer(int64_t capacity, std::vector<uint8_t>* source,
+                const LebGenerator& leb_generator = *LebGenerator::Create());
+
+  /*!\brief Destructor.*/
+  ~ReadBitBuffer() = default;
+
+  /*!\brief Reads AND consumes the lower `num_bits` from buffer into `data`.
+   *
+   * \param data Data from buffer will be written here.
+   * \param num_bits Number of lower bits of the data to read. Maximum value of
+   *     64.
+   * \return `absl::OkStatus()` on success. `absl::InvalidArgumentError()` if
+   *     `num_bits > 64`. `absl::UnknownError()` if the `rb->bit_offset` is
+   *     negative.
+   */
+  absl::Status ReadUnsignedLiteral(uint64_t* data, int num_bits);
+
+  /*!\brief Gets the offset in bits of the buffer.
+   *
+   * \return Offset in bits of the read buffer.
+   */
+  int64_t bit_offset() const { return bit_buffer_offset_; }
+
+  /*!\brief Checks whether the current data in the buffer is byte-aligned.
+   *
+   * \return `true` when the current data in the buffer is byte-aligned.
+   */
+  bool IsByteAligned() const { return bit_buffer_offset_ % 8 == 0; }
+
+  /*!\brief Loads data from source into the read buffer.
+   *
+   * Loads exactly enough bytes from `source_` into `bit_buffer_` such that
+   * it contains at least `required_num_bits` bits. Load bits updates the
+   * `source_offset_` based on the number of bytes that were loaded into the
+   * buffer.
+   *
+   * \return `absl::OkStatus()` on success.
+   */
+  absl::Status LoadBits(int32_t required_num_bits);
+
+  /*!\brief Empties the buffer.*/
+  absl::Status DiscardAllBits();
+
+  LebGenerator leb_generator_;
+
+ private:
+  // Read buffer.
+  std::vector<uint8_t> bit_buffer_;
+  // Specifies the next bit to consume in the `bit_buffer_`.
+  int64_t bit_buffer_offset_ = 0;
+  // Pointer to the source data.
+  std::vector<uint8_t>* source_;
+  // Specifies the next byte to consume from the source data `source_`.
+  int64_t source_offset_ = 0;
+};
+
+}  // namespace iamf_tools
+
+#endif  // READ_BIT_BUFFER_H_

--- a/iamf/temporal_delimiter.h
+++ b/iamf/temporal_delimiter.h
@@ -30,9 +30,7 @@ class TemporalDelimiterObu : public ObuBase {
   TemporalDelimiterObu(TemporalDelimiterObu&& other) = default;
 
   /*!\brief Destructor. */
-  ~TemporalDelimiterObu() override {
-    // There is no memory to clean up for a Temporal Delimiter OBU.
-  }
+  ~TemporalDelimiterObu() override = default;
 
   /*\!brief Prints logging information about the OBU.*/
   void PrintObu() const override {

--- a/iamf/tests/BUILD
+++ b/iamf/tests/BUILD
@@ -282,6 +282,16 @@ cc_test(
         "//iamf:write_bit_buffer",
         "//iamf/cli:leb_generator",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "read_bit_buffer_test",
+    srcs = ["read_bit_buffer_test.cc"],
+    deps = [
+        "//iamf:read_bit_buffer",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/iamf/tests/arbitrary_obu_test.cc
+++ b/iamf/tests/arbitrary_obu_test.cc
@@ -38,7 +38,7 @@ class ArbitraryObuTest : public ObuTestBase, public testing::Test {
         payload_({}),
         insertion_hook_(ArbitraryObu::kInsertionHookBeforeDescriptors) {}
 
-  ~ArbitraryObuTest() override {}
+  ~ArbitraryObuTest() override = default;
 
  protected:
   void Init() override {

--- a/iamf/tests/audio_element_test.cc
+++ b/iamf/tests/audio_element_test.cc
@@ -91,7 +91,7 @@ class AudioElementObuTestBase : public ObuTestBase {
                           std::move(param_definition)});
   }
 
-  ~AudioElementObuTestBase() {}
+  ~AudioElementObuTestBase() = default;
 
  protected:
   void Init() override {

--- a/iamf/tests/audio_frame_test.cc
+++ b/iamf/tests/audio_frame_test.cc
@@ -37,7 +37,7 @@ class AudioFrameObuTest : public ObuTestBase, public testing::Test {
         audio_substream_id_(0),
         audio_frame_({42}) {}
 
-  ~AudioFrameObuTest() override {}
+  ~AudioFrameObuTest() override = default;
 
  protected:
   void Init() override {

--- a/iamf/tests/codec_config_test.cc
+++ b/iamf/tests/codec_config_test.cc
@@ -40,7 +40,7 @@ class CodecConfigTestBase : public ObuTestBase {
                        .audio_roll_distance = 0,
                        .decoder_config = decoder_config}) {}
 
-  ~CodecConfigTestBase() override {}
+  ~CodecConfigTestBase() override = default;
 
  protected:
   void Init() override {
@@ -372,13 +372,10 @@ TEST_F(CodecConfigLpcmTest, RedundantCopy) {
 class CodecConfigOpusTest : public CodecConfigTestBase, public testing::Test {
  public:
   CodecConfigOpusTest()
-      : CodecConfigTestBase(CodecConfig::kCodecIdOpus,
-                            OpusDecoderConfig{.version_ = 1,
-                                              .output_channel_count_ = 2,
-                                              .pre_skip_ = 0,
-                                              .input_sample_rate_ = 0,
-                                              .output_gain_ = 0,
-                                              .mapping_family_ = 0}) {
+      : CodecConfigTestBase(
+            CodecConfig::kCodecIdOpus,
+            OpusDecoderConfig{
+                .version_ = 1, .pre_skip_ = 0, .input_sample_rate_ = 0}) {
     // Overwrite some default values to be more reasonable for Opus.
     codec_config_.num_samples_per_frame = 960;
     codec_config_.audio_roll_distance = -4;
@@ -413,7 +410,7 @@ TEST_F(CodecConfigOpusTest, ManyLargeValues) {
                        // `version`.
                        1,
                        // `output_channel_count`.
-                       2,
+                       OpusDecoderConfig::kOutputChannelCount,
                        // `pre_skip`
                        0xff, 0xff,
                        //
@@ -422,7 +419,7 @@ TEST_F(CodecConfigOpusTest, ManyLargeValues) {
                        // `output_gain`.
                        0, 0,
                        // `mapping_family`.
-                       0};
+                       OpusDecoderConfig::kMappingFamily};
 
   InitAndTestWrite();
 }
@@ -453,7 +450,7 @@ TEST_F(CodecConfigOpusTest, VarySeveralFields) {
                        // `version`.
                        15,
                        // `output_channel_count`.
-                       2,
+                       OpusDecoderConfig::kOutputChannelCount,
                        // `pre_skip`
                        0, 3,
                        //
@@ -462,7 +459,7 @@ TEST_F(CodecConfigOpusTest, VarySeveralFields) {
                        // `output_gain`.
                        0, 0,
                        // `mapping_family`.
-                       0};
+                       OpusDecoderConfig::kMappingFamily};
   InitAndTestWrite();
 }
 

--- a/iamf/tests/flac_decoder_config_test.cc
+++ b/iamf/tests/flac_decoder_config_test.cc
@@ -32,18 +32,12 @@ class FlacTest : public testing::Test {
             {{.header = {.last_metadata_block_flag = true,
                          .block_type = FlacMetaBlockHeader::kFlacStreamInfo,
                          .metadata_data_block_length = 34},
-              .payload = FlacMetaBlockStreamInfo{
-                  .minimum_block_size = 16,
-                  .maximum_block_size = 16,
-                  .minimum_frame_size = 0,
-                  .maximum_frame_size = 0,
-                  .sample_rate = 48000,
-                  .number_of_channels = 1,
-                  .bits_per_sample = 15,
-                  .total_samples_in_stream = 0,
-                  .md5_signature = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                    0x00, 0x00}}}}) {
+              .payload =
+                  FlacMetaBlockStreamInfo{.minimum_block_size = 16,
+                                          .maximum_block_size = 16,
+                                          .sample_rate = 48000,
+                                          .bits_per_sample = 15,
+                                          .total_samples_in_stream = 0}}}) {
     first_stream_info_payload_ = &std::get<FlacMetaBlockStreamInfo>(
         flac_decoder_config_.metadata_blocks_[0].payload);
   }
@@ -99,7 +93,7 @@ TEST_F(FlacTest, WriteDefault) {
       0x0b, 0xb8,
       (0 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1),
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1),
       15 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -143,7 +137,7 @@ TEST_F(FlacTest, CanContainAdditionalBlocks) {
       0x0b, 0xb8,
       (0 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1),
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1),
       15 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -241,7 +235,7 @@ TEST_F(FlacTest, WriteBitsPerSampleMin) {
       0x0b, 0xb8,
       (0 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1),
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1),
       3 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -273,7 +267,7 @@ TEST_F(FlacTest, WriteBitsPerSampleMax) {
       0x0b, 0xb8,
       (0 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1) | 1,
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1) | 1,
       15 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -286,17 +280,12 @@ TEST_F(FlacTest, WriteBitsPerSampleMax) {
 
 TEST_F(FlacTest, WriteVaryMostLegalFields) {
   num_samples_per_frame_ = 64;
-  flac_decoder_config_.metadata_blocks_[0].payload = FlacMetaBlockStreamInfo{
-      .minimum_block_size = 64,
-      .maximum_block_size = 64,
-      .minimum_frame_size = 0,
-      .maximum_frame_size = 0,
-      .sample_rate = 48000,
-      .number_of_channels = 1,
-      .bits_per_sample = 7,
-      .total_samples_in_stream = 100,
-      .md5_signature = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  flac_decoder_config_.metadata_blocks_[0].payload =
+      FlacMetaBlockStreamInfo{.minimum_block_size = 64,
+                              .maximum_block_size = 64,
+                              .sample_rate = 48000,
+                              .bits_per_sample = 7,
+                              .total_samples_in_stream = 100};
 
   expected_decoder_config_payload_ = {
       // `last_metadata_block_flag` and `block_type` fields.
@@ -315,7 +304,7 @@ TEST_F(FlacTest, WriteVaryMostLegalFields) {
       0x0b, 0xb8,
       (0 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          1 << 1,
+          FlacMetaBlockStreamInfo::kNumberOfChannels << 1,
       7 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -347,7 +336,7 @@ TEST_F(FlacTest, WriteSampleRateMin) {
       0x00, 0x00,
       (0x1 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1),
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1),
       15 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -379,7 +368,7 @@ TEST_F(FlacTest, WriteSampleRateMax) {
       0x9f, 0xff,
       (0x6 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1),
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1),
       15 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -443,7 +432,7 @@ TEST_F(FlacTest, WriteMinimumMaximumBlockSizeMax) {
       0x0b, 0xb8,
       (0 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1),
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1),
       15 << 4 |
           // `total_samples_in_stream` (36 bits).
           0,
@@ -491,27 +480,32 @@ TEST_F(FlacTest, IllegalMinimumMaximumBlockSizeNotEqualToEachOther) {
   TestWriteDecoderConfig();
 }
 
-TEST_F(FlacTest, IllegalMinimumMaximumFrameSizeNotEqualToZero) {
-  first_stream_info_payload_->minimum_frame_size = 16;
-  first_stream_info_payload_->maximum_frame_size = 16;
+TEST_F(FlacTest, IllegalMinimumFrameSizeNotEqualToZero) {
+  const uint32_t kInvalidMinimumFrameSize = 16;
+  ASSERT_NE(kInvalidMinimumFrameSize,
+            FlacMetaBlockStreamInfo::kMinimumFrameSize);
+  first_stream_info_payload_->minimum_frame_size = kInvalidMinimumFrameSize;
+
   expected_write_status_code_ = absl::StatusCode::kInvalidArgument;
   TestWriteDecoderConfig();
 }
 
-TEST_F(FlacTest, IllegalNumberOfChannelsTooLow) {
-  first_stream_info_payload_->number_of_channels = 0;
+TEST_F(FlacTest, IllegalMaximumFrameSizeNotEqualToZero) {
+  const uint32_t kInvalidMaximumFrameSize = 16;
+  ASSERT_NE(kInvalidMaximumFrameSize,
+            FlacMetaBlockStreamInfo::kMaximumFrameSize);
+  first_stream_info_payload_->maximum_frame_size = kInvalidMaximumFrameSize;
+
   expected_write_status_code_ = absl::StatusCode::kInvalidArgument;
   TestWriteDecoderConfig();
 }
 
-TEST_F(FlacTest, IllegalNumberOfChannelsTooHigh) {
-  first_stream_info_payload_->number_of_channels = 2;
-  expected_write_status_code_ = absl::StatusCode::kInvalidArgument;
-  TestWriteDecoderConfig();
-}
+TEST_F(FlacTest, IllegalNumberOfChannelsNotEqualToOne) {
+  const uint8_t kInvalidNumberOfChannels = 2;
+  ASSERT_NE(kInvalidNumberOfChannels,
+            FlacMetaBlockStreamInfo::kNumberOfChannels);
+  first_stream_info_payload_->number_of_channels = kInvalidNumberOfChannels;
 
-TEST_F(FlacTest, IllegalNumberOfChannelsMax) {
-  first_stream_info_payload_->number_of_channels = 7;
   expected_write_status_code_ = absl::StatusCode::kInvalidArgument;
   TestWriteDecoderConfig();
 }
@@ -537,7 +531,7 @@ TEST_F(FlacTest, WriteTotalSamplesInStreamMax) {
       0x0b, 0xb8,
       (0 << 4) |
           // `number_of_channels` (3 bits) and `bits_per_sample` (5 bits).
-          (1 << 1),
+          (FlacMetaBlockStreamInfo::kNumberOfChannels << 1),
       15 << 4 |
           // `total_samples_in_stream` (36 bits).
           0xf,
@@ -549,7 +543,10 @@ TEST_F(FlacTest, WriteTotalSamplesInStreamMax) {
 }
 
 TEST_F(FlacTest, IllegalMd5SumNonZero) {
-  first_stream_info_payload_->md5_signature[0] = 0x01;
+  const uint8_t kInvalidMd5SumFirstByte = 0x01;
+  ASSERT_NE(FlacMetaBlockStreamInfo::kMd5Signature[0], kInvalidMd5SumFirstByte);
+  first_stream_info_payload_->md5_signature[0] = kInvalidMd5SumFirstByte;
+
   expected_write_status_code_ = absl::StatusCode::kInvalidArgument;
   TestWriteDecoderConfig();
 }

--- a/iamf/tests/ia_sequence_header_test.cc
+++ b/iamf/tests/ia_sequence_header_test.cc
@@ -49,7 +49,7 @@ class IASequenceHeaderObuTestBase : public ObuTestBase {
             .additional_profile = ProfileVersion::kIamfSimpleProfile,
         }) {}
 
-  ~IASequenceHeaderObuTestBase() override {}
+  ~IASequenceHeaderObuTestBase() override = default;
 
  protected:
   void Init() override {

--- a/iamf/tests/obu_base_test.cc
+++ b/iamf/tests/obu_base_test.cc
@@ -25,7 +25,7 @@ namespace {
 class ImaginaryObuNonIntegerBytes : public ObuBase {
  public:
   ImaginaryObuNonIntegerBytes() : ObuBase(kObuIaReserved24) {}
-  ~ImaginaryObuNonIntegerBytes() override {}
+  ~ImaginaryObuNonIntegerBytes() override = default;
   void PrintObu() const override {}
 
  private:
@@ -49,7 +49,7 @@ class OneByteObu : public ObuBase {
   explicit OneByteObu(const ObuHeader& header)
       : ObuBase(header, kObuIaReserved24) {}
 
-  ~OneByteObu() override {}
+  ~OneByteObu() override = default;
   void PrintObu() const override {}
 
  private:

--- a/iamf/tests/obu_util_test.cc
+++ b/iamf/tests/obu_util_test.cc
@@ -641,5 +641,17 @@ TEST(WritePcmSample, InvalidOver32Bits) {
             absl::StatusCode::kInvalidArgument);
 }
 
+TEST(ValidateEqual, OkIfArgsAreEqual) {
+  const auto kLeftArg = 123;
+  const auto kRightArg = 123;
+  EXPECT_TRUE(ValidateEqual(kLeftArg, kRightArg, "").ok());
+}
+
+TEST(ValidateEqual, NotOkIfArgsAreNotEqual) {
+  const auto kLeftArg = 123;
+  const auto kUnequalRightArg = 223;
+  EXPECT_FALSE(ValidateEqual(kLeftArg, kUnequalRightArg, "").ok());
+}
+
 }  // namespace
 }  // namespace iamf_tools

--- a/iamf/tests/opus_decoder_config_test.cc
+++ b/iamf/tests/opus_decoder_config_test.cc
@@ -24,14 +24,8 @@ namespace {
 
 class OpusTest : public testing::Test {
  public:
-  OpusTest()
-      : opus_decoder_config_({.version_ = 1,
-                              .output_channel_count_ = 2,
-                              .pre_skip_ = 0,
-                              .input_sample_rate_ = 0,
-                              .output_gain_ = 0,
-                              .mapping_family_ = 0}) {}
-  ~OpusTest() {}
+  OpusTest() : opus_decoder_config_({.version_ = 1, .pre_skip_ = 0}) {}
+  ~OpusTest() = default;
 
  protected:
   void TestWriteDecoderConfig() {
@@ -59,11 +53,21 @@ class OpusTest : public testing::Test {
   std::vector<uint8_t> expected_decoder_config_payload_;
 };
 
+TEST(OpusDecoderConfig, IamfFixedFieldsAreDefault) {
+  OpusDecoderConfig decoder_config;
+  // The IAMF spec REQUIRES fixed fields for all Opus Decoder Configs. Verify
+  // the default constructor configures these to the fixed values.
+  EXPECT_EQ(decoder_config.output_channel_count_,
+            OpusDecoderConfig::kOutputChannelCount);
+  EXPECT_EQ(decoder_config.output_gain_, OpusDecoderConfig::kOutputGain);
+  EXPECT_EQ(decoder_config.mapping_family_, OpusDecoderConfig::kMappingFamily);
+}
+
 TEST_F(OpusTest, WriteDefault) {
   expected_decoder_config_payload_ = {// `version`.
                                       1,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0, 0,
                                       // `input_sample_rate`.
@@ -71,21 +75,17 @@ TEST_F(OpusTest, WriteDefault) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
 TEST_F(OpusTest, VaryAllLegalFields) {
-  opus_decoder_config_ = {.version_ = 2,
-                          .output_channel_count_ = 2,
-                          .pre_skip_ = 3,
-                          .input_sample_rate_ = 4,
-                          .output_gain_ = 0,
-                          .mapping_family_ = 0};
+  opus_decoder_config_ = {
+      .version_ = 2, .pre_skip_ = 3, .input_sample_rate_ = 4};
   expected_decoder_config_payload_ = {// `version`.
                                       2,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0, 3,
                                       // `input_sample_rate`.
@@ -93,21 +93,17 @@ TEST_F(OpusTest, VaryAllLegalFields) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
 TEST_F(OpusTest, MaxAllLegalFields) {
-  opus_decoder_config_ = {.version_ = 15,
-                          .output_channel_count_ = 2,
-                          .pre_skip_ = 0xffff,
-                          .input_sample_rate_ = 0xffffffff,
-                          .output_gain_ = 0,
-                          .mapping_family_ = 0};
+  opus_decoder_config_ = {
+      .version_ = 15, .pre_skip_ = 0xffff, .input_sample_rate_ = 0xffffffff};
   expected_decoder_config_payload_ = {// `version`.
                                       15,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0xff, 0xff,
                                       // `input_sample_rate`.
@@ -115,7 +111,7 @@ TEST_F(OpusTest, MaxAllLegalFields) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
@@ -124,7 +120,7 @@ TEST_F(OpusTest, MinorVersion) {
   expected_decoder_config_payload_ = {// `version`.
                                       2,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0, 0,
                                       // `input_sample_rate`.
@@ -132,7 +128,7 @@ TEST_F(OpusTest, MinorVersion) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
@@ -177,7 +173,7 @@ TEST_F(OpusTest, WritePreSkip) {
   expected_decoder_config_payload_ = {// `version`.
                                       1,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0, 1,
                                       // `input_sample_rate`.
@@ -185,7 +181,7 @@ TEST_F(OpusTest, WritePreSkip) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
@@ -194,7 +190,7 @@ TEST_F(OpusTest, WritePreSkip312) {
   expected_decoder_config_payload_ = {// `version`.
                                       1,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0x01, 0x38,
                                       // `input_sample_rate`.
@@ -202,7 +198,7 @@ TEST_F(OpusTest, WritePreSkip312) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
@@ -211,7 +207,7 @@ TEST_F(OpusTest, WriteSampleRate48kHz) {
   expected_decoder_config_payload_ = {// `version`.
                                       1,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0, 0,
                                       // `input_sample_rate`.
@@ -219,7 +215,7 @@ TEST_F(OpusTest, WriteSampleRate48kHz) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
@@ -228,7 +224,7 @@ TEST_F(OpusTest, WriteSampleRate192kHz) {
   expected_decoder_config_payload_ = {// `version`.
                                       1,
                                       // `output_channel_count`.
-                                      2,
+                                      OpusDecoderConfig::kOutputChannelCount,
                                       // `pre_skip`.
                                       0, 0,
                                       // `input_sample_rate`.
@@ -236,7 +232,7 @@ TEST_F(OpusTest, WriteSampleRate192kHz) {
                                       // `output_gain`.
                                       0, 0,
                                       // `mapping_family`.
-                                      0};
+                                      OpusDecoderConfig::kMappingFamily};
   TestWriteDecoderConfig();
 }
 
@@ -281,12 +277,8 @@ class OpusDecoderConfigTestForAudioRollDistance
  protected:
   // A decoder config with reasonable default values. They are not relevant to
   // the test.
-  const OpusDecoderConfig opus_decoder_config_ = {.version_ = 1,
-                                                  .output_channel_count_ = 2,
-                                                  .pre_skip_ = 312,
-                                                  .input_sample_rate_ = 0,
-                                                  .output_gain_ = 0,
-                                                  .mapping_family_ = 0};
+  const OpusDecoderConfig opus_decoder_config_ = {
+      .version_ = 1, .pre_skip_ = 312, .input_sample_rate_ = 0};
 };
 
 TEST_P(OpusDecoderConfigTestForAudioRollDistance, TestOpusDecoderConfig) {

--- a/iamf/tests/parameter_block_test.cc
+++ b/iamf/tests/parameter_block_test.cc
@@ -52,7 +52,7 @@ class ParameterBlockObuTestBase : public ObuTestBase {
             .constant_subblock_duration = 64,
         }) {}
 
-  ~ParameterBlockObuTestBase() {}
+  ~ParameterBlockObuTestBase() = default;
 
  protected:
   void Init() override {

--- a/iamf/tests/read_bit_buffer_test.cc
+++ b/iamf/tests/read_bit_buffer_test.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#include "iamf/read_bit_buffer.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace iamf_tools {
+namespace {
+
+class ReadBitBufferTest : public ::testing::Test {
+ public:
+  std::vector<uint8_t> rb_data_;
+  int64_t rb_capacity_;
+  std::unique_ptr<ReadBitBuffer> CreateReadBitBuffer() {
+    return std::make_unique<ReadBitBuffer>(rb_capacity_, &rb_data_);
+  }
+};
+
+TEST_F(ReadBitBufferTest, ReadBitBufferConstructor) {
+  rb_data_ = {};
+  rb_capacity_ = 0;
+  std::unique_ptr<ReadBitBuffer> rb_ = CreateReadBitBuffer();
+  EXPECT_NE(rb_, nullptr);
+}
+
+}  // namespace
+}  // namespace iamf_tools

--- a/iamf/tests/temporal_delimiter_test.cc
+++ b/iamf/tests/temporal_delimiter_test.cc
@@ -32,7 +32,7 @@ class TemporalDelimiterTestBase : public ObuTestBase {
             /*expected_payload=*/{}),
         obu_() {}
 
-  ~TemporalDelimiterTestBase() override {}
+  ~TemporalDelimiterTestBase() override = default;
 
  protected:
   void Init() override {

--- a/iamf/write_bit_buffer.h
+++ b/iamf/write_bit_buffer.h
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <string>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -25,6 +26,13 @@ namespace iamf_tools {
 /*!\brief Holds a buffer and tracks the next bit to be written to. */
 class WriteBitBuffer {
  public:
+  /*!\brief The maximum length of an IAMF string in bytes.
+   *
+   * The spec limits the length of a string to 128 bytes including the
+   * null terminator ('\0').
+   */
+  static constexpr int kIamfMaxStringSize = 128;
+
   /*!\brief Constructor.
    *
    * \param initial_capacity Initial capacity of the internal buffer in bytes.
@@ -88,7 +96,7 @@ class WriteBitBuffer {
    *     `absl::Status::kResourceExhausted` if there is not enough room in the
    *     write buffer. Other specific statuses on failure.
    */
-  absl::Status WriteString(const IamfString data);
+  absl::Status WriteString(const std::string& data);
 
   /*!\brief Writes a `std::vector<uint8_t>` to the write buffer.
    *


### PR DESCRIPTION
  - 606263281 Add test coverage for UTF-8 support and fix a bug on syst... by jwcullen <jwcullen@google.com>
  - 606261778 `mix_presentation.cc`: Fill in error messages. by jwcullen <jwcullen@google.com>
  - 605698929 Fix inconsistent include guards. by jwcullen <jwcullen@google.com>
  - 605387309 Adjust `WriteBitBuffer::WriteString` to take in an `std::... by jwcullen <jwcullen@google.com>
  - 605352008 Fix gerrit build broken by cl/604973064. by jwcullen <jwcullen@google.com>
  - 604973571 Make rule for `audio_to_tactile` includes reversible. by jwcullen <jwcullen@google.com>
  - 604973064 Defines a class that provides (labeled) samples read from... by yero <yero@google.com>
  - 604810550 Default `ia_code` to the correct value in input protos. by jwcullen <jwcullen@google.com>
  - 604810139 `FlacDecoderConfig`: Give IAMF-fixed fields default value... by jwcullen <jwcullen@google.com>
  - 604809863 `AacDecoderConfig`: Give IAMF-fixed fields default values... by jwcullen <jwcullen@google.com>
  - 604807625 `OpusDecoderConfig` proto: Provide default values for IAM... by jwcullen <jwcullen@google.com>
  - 604613847 Create a function to validate in arguments are equal. Use... by jwcullen <jwcullen@google.com>
  - 604292623 `OpusDecoderConfig`: Give IAMF-fixed fields default values. by jwcullen <jwcullen@google.com>
  - 604292407 Fill in error messages in codec config generator and incr... by jwcullen <jwcullen@google.com>
  - 604200971 [Style] Prefer `default` for trivial destructors. by jwcullen <jwcullen@google.com>
  - 603739135 Create read_bit_buffer.h, read_bit_buffer.cc, and read_bi... by Googler <copybara-servicebot@google.com>
  - 603359448 Fill in error messages in some OBU generators. by jwcullen <jwcullen@google.com>
  - 603356593 Add a lookup table and use it for AAC encoder error codes.  by jwcullen <jwcullen@google.com>
  - 603048022 Initialize `element_mix_config` in `MixPresentationObuTes... by jwcullen <jwcullen@google.com>
  - 602402841 Add an override for the bit-depth of output "rendered" wa... by jwcullen <jwcullen@google.com>

PiperOrigin-RevId: 606263281