### PR TITLE
Add Compile Support For MacOs / ARM

### DIFF
--- a/external/fdk_aac.BUILD
+++ b/external/fdk_aac.BUILD
@@ -20,6 +20,13 @@ cc_library(
     ],
 )
 
+ARM_HEADERS = glob([
+    "libFDK/include/arm/*.h",
+    "libFDK/src/arm/*.cpp",
+])
+
+X86_HEADERS = glob(["libFDK/include/x86/*.h"])
+
 cc_library(
     name = "fdk_core_lib",
     srcs = glob([
@@ -28,14 +35,15 @@ cc_library(
     ]),
     hdrs = glob([
         "libFDK/include/*.h",
-        "libFDK/include/x86/*.h",
-        "libFDK/include/arm/*.h",
-        "libFDK/src/arm/*.cpp"
-    ]),
+    ]) + select({
+        "@platforms//cpu:arm": ARM_HEADERS,
+        "@platforms//cpu:x86_32": X86_HEADERS,
+        "@platforms//cpu:x86_64": X86_HEADERS,
+    }),
     includes = [
         "libFDK/include",
-        "libSYS/include",
         "libFDK/src",
+        "libSYS/include",
     ],
     deps = [
         ":fdk_sys_lib",
@@ -223,14 +231,17 @@ cc_library(
     ]),
     hdrs = glob([
         "libAACdec/include/*.h",
-        "libAACdec/src/arm/*.cpp"
-    ]),
+    ]) + select({
+        "@platforms//cpu:arm": ARM_HEADERS,
+         "//conditions:default": [],
+    }),
     copts = [
         "-Wno-implicit-fallthrough",
         "-Wno-unused-variable",
     ],
     includes = [
         "libAACdec/include",
+        "libAACdec/src",
         "libArithCoding/include",
         "libDRCdec/include",
         "libFDK/include",
@@ -239,7 +250,6 @@ cc_library(
         "libSACdec/include",
         "libSACenc/include",
         "libSBRdec/include",
-        "libAACdec/src",
     ],
     deps = [
         ":arith_coding_lib",

--- a/external/fdk_aac.BUILD
+++ b/external/fdk_aac.BUILD
@@ -29,10 +29,13 @@ cc_library(
     hdrs = glob([
         "libFDK/include/*.h",
         "libFDK/include/x86/*.h",
+        "libFDK/include/arm/*.h",
+        "libFDK/src/arm/*.cpp"
     ]),
     includes = [
         "libFDK/include",
         "libSYS/include",
+        "libFDK/src",
     ],
     deps = [
         ":fdk_sys_lib",
@@ -220,6 +223,7 @@ cc_library(
     ]),
     hdrs = glob([
         "libAACdec/include/*.h",
+        "libAACdec/src/arm/*.cpp"
     ]),
     copts = [
         "-Wno-implicit-fallthrough",
@@ -235,6 +239,7 @@ cc_library(
         "libSACdec/include",
         "libSACenc/include",
         "libSBRdec/include",
+        "libAACdec/src",
     ],
     deps = [
         ":arith_coding_lib",

--- a/external/fdk_aac.BUILD
+++ b/external/fdk_aac.BUILD
@@ -37,6 +37,8 @@ cc_library(
         "libFDK/include/*.h",
     ]) + select({
         "@platforms//cpu:arm": ARM_HEADERS,
+        "@platforms//cpu:armv7": ARM_HEADERS,
+        "@platforms//cpu:arm64": ARM_HEADERS,
         "@platforms//cpu:x86_32": X86_HEADERS,
         "@platforms//cpu:x86_64": X86_HEADERS,
     }),
@@ -233,6 +235,8 @@ cc_library(
         "libAACdec/include/*.h",
     ]) + select({
         "@platforms//cpu:arm": ARM_HEADERS,
+        "@platforms//cpu:armv7": ARM_HEADERS,
+        "@platforms//cpu:arm64": ARM_HEADERS,
          "//conditions:default": [],
     }),
     copts = [

--- a/external/fdk_aac.BUILD
+++ b/external/fdk_aac.BUILD
@@ -20,13 +20,6 @@ cc_library(
     ],
 )
 
-ARM_HEADERS = glob([
-    "libFDK/include/arm/*.h",
-    "libFDK/src/arm/*.cpp",
-])
-
-X86_HEADERS = glob(["libFDK/include/x86/*.h"])
-
 cc_library(
     name = "fdk_core_lib",
     srcs = glob([
@@ -35,17 +28,14 @@ cc_library(
     ]),
     hdrs = glob([
         "libFDK/include/*.h",
-    ]) + select({
-        "@platforms//cpu:arm": ARM_HEADERS,
-        "@platforms//cpu:armv7": ARM_HEADERS,
-        "@platforms//cpu:arm64": ARM_HEADERS,
-        "@platforms//cpu:x86_32": X86_HEADERS,
-        "@platforms//cpu:x86_64": X86_HEADERS,
-    }),
+        "libFDK/include/x86/*.h",
+        "libFDK/include/arm/*.h",
+        "libFDK/src/arm/*.cpp"
+    ]),
     includes = [
         "libFDK/include",
-        "libFDK/src",
         "libSYS/include",
+        "libFDK/src",
     ],
     deps = [
         ":fdk_sys_lib",
@@ -233,19 +223,14 @@ cc_library(
     ]),
     hdrs = glob([
         "libAACdec/include/*.h",
-    ]) + select({
-        "@platforms//cpu:arm": ARM_HEADERS,
-        "@platforms//cpu:armv7": ARM_HEADERS,
-        "@platforms//cpu:arm64": ARM_HEADERS,
-         "//conditions:default": [],
-    }),
+        "libAACdec/src/arm/*.cpp"
+    ]),
     copts = [
         "-Wno-implicit-fallthrough",
         "-Wno-unused-variable",
     ],
     includes = [
         "libAACdec/include",
-        "libAACdec/src",
         "libArithCoding/include",
         "libDRCdec/include",
         "libFDK/include",
@@ -254,6 +239,7 @@ cc_library(
         "libSACdec/include",
         "libSACenc/include",
         "libSBRdec/include",
+        "libAACdec/src",
     ],
     deps = [
         ":arith_coding_lib",


### PR DESCRIPTION
Added missing includes, headers and src files in order to allow compilation on MacOs with ARM architecture. Note that in order to complete the compile expat_config.h is also needed but it looks like this will be handled by https://github.com/AOMediaCodec/iamf-tools/issues/5 .