### PR TITLE
Initial version of coupling rate adjustment

### DIFF
--- a/iamf/cli/proto/codec_config.proto
+++ b/iamf/cli/proto/codec_config.proto
@@ -40,6 +40,7 @@ message OpusEncoderMetadata {
   optional int32 target_bitrate_per_channel = 1;
   optional OpusApplicationFlag application = 2;
   optional bool use_float_api = 3 [default = true];
+  optional float coupling_rate_adjustment = 4 [default = 1.0];
 }
 
 message OpusDecoderConfig {


### PR DESCRIPTION
This is a minor proposal in order to have bit more control on the bitrate adjustment of coupled audio substreams. When coupling channel pairs, most codecs such as Opus utilize efficient coding based on channel correlations. It may well be that the default of giving coupled channel pairs the double of the default bitrate is overkill, in case competitive bitrates are required. This simple coefficient makes it possible to adjust this by using it in the `.textproto`-file e.g.: 
```
opus_encoder_metadata {
  target_bitrate_per_channel: 48000
  application: APPLICATION_AUDIO
  use_float_api: false
  coupling_rate_adjustment: 0.7
}
```