### PR TITLE
Add individual rate adjustment per substream for Opus

### DIFF
--- a/iamf/cli/codec/opus_encoder.cc
+++ b/iamf/cli/codec/opus_encoder.cc
@@ -163,7 +163,7 @@ absl::Status OpusEncoder::InitializeEncoder() {
   } else {
     opus_rate =
         encoder_metadata_.use_substream_rate_override()
-            ? (float)encoder_metadata_.substream_rate_overrides()[substream_id_]
+            ? encoder_metadata_.substream_rate_overrides()[substream_id_]
             : encoder_metadata_.target_bitrate_per_channel();
   }
   opus_encoder_ctl(encoder_,

--- a/iamf/cli/codec/opus_encoder.cc
+++ b/iamf/cli/codec/opus_encoder.cc
@@ -154,8 +154,8 @@ absl::Status OpusEncoder::InitializeEncoder() {
   // Configure `libopus` so coupled substreams and mono substreams have equally
   // effective bit-rate per channel.
   float opus_rate;
-  if (encoder_metadata_.substream_id_to_bitrate_override().count(
-          substream_id_) == 1) {
+  if (encoder_metadata_.substream_id_to_bitrate_override().contains(
+          substream_id_)) {
     opus_rate =
         encoder_metadata_.substream_id_to_bitrate_override().at(substream_id_);
   } else if (num_channels_ > 1) {

--- a/iamf/cli/codec/opus_encoder.cc
+++ b/iamf/cli/codec/opus_encoder.cc
@@ -154,17 +154,15 @@ absl::Status OpusEncoder::InitializeEncoder() {
   // Configure `libopus` so coupled substreams and mono substreams have equally
   // effective bit-rate per channel.
   float opus_rate;
-  if (num_channels_ > 1) {
+  if (encoder_metadata_.substream_id_to_bitrate_override().count(
+          substream_id_) == 1) {
     opus_rate =
-        encoder_metadata_.use_substream_rate_override()
-            ? encoder_metadata_.substream_rate_overrides()[substream_id_]
-            : encoder_metadata_.target_bitrate_per_channel() * num_channels_ *
-                  encoder_metadata_.coupling_rate_adjustment();
+        encoder_metadata_.substream_id_to_bitrate_override().at(substream_id_);
+  } else if (num_channels_ > 1) {
+    opus_rate = encoder_metadata_.target_bitrate_per_channel() * num_channels_ *
+                encoder_metadata_.coupling_rate_adjustment();
   } else {
-    opus_rate =
-        encoder_metadata_.use_substream_rate_override()
-            ? encoder_metadata_.substream_rate_overrides()[substream_id_]
-            : encoder_metadata_.target_bitrate_per_channel();
+    opus_rate = encoder_metadata_.target_bitrate_per_channel();
   }
   opus_encoder_ctl(encoder_,
                    OPUS_SET_BITRATE(static_cast<opus_int32>(opus_rate + 0.5f)));

--- a/iamf/cli/codec/opus_encoder.h
+++ b/iamf/cli/codec/opus_encoder.h
@@ -30,11 +30,12 @@ class OpusEncoder : public EncoderBase {
  public:
   OpusEncoder(
       const iamf_tools_cli_proto::OpusEncoderMetadata& opus_encoder_metadata,
-      const CodecConfigObu& codec_config, int num_channels)
+      const CodecConfigObu& codec_config, int num_channels, int substream_id)
       : EncoderBase(false, codec_config, num_channels),
         encoder_metadata_(opus_encoder_metadata),
         decoder_config_(std::get<OpusDecoderConfig>(
-            codec_config.GetCodecConfig().decoder_config)) {}
+            codec_config.GetCodecConfig().decoder_config)),
+        substream_id_(substream_id) {}
 
   ~OpusEncoder() override;
 
@@ -84,6 +85,7 @@ class OpusEncoder : public EncoderBase {
 
   const iamf_tools_cli_proto::OpusEncoderMetadata encoder_metadata_;
   const OpusDecoderConfig decoder_config_;
+  const int substream_id_;
 
   LibOpusEncoder* encoder_ = nullptr;
 };

--- a/iamf/cli/codec/tests/encoder_test_base.h
+++ b/iamf/cli/codec/tests/encoder_test_base.h
@@ -112,6 +112,7 @@ class EncoderTestBase {
   }
 
   int num_channels_ = 1;
+  int substream_id_ = 0;
   uint32_t num_samples_per_frame_ = 1;
   int8_t input_sample_size_ = 16;
   std::unique_ptr<EncoderBase> encoder_;

--- a/iamf/cli/codec/tests/opus_encoder_test.cc
+++ b/iamf/cli/codec/tests/opus_encoder_test.cc
@@ -54,7 +54,7 @@ class OpusEncoderTest : public EncoderTestBase, public testing::Test {
     EXPECT_THAT(codec_config.Initialize(), IsOk());
 
     encoder_ = std::make_unique<OpusEncoder>(opus_encoder_metadata_,
-                                             codec_config, num_channels_);
+                                             codec_config, num_channels_, substream_id_);
   }
 
   OpusDecoderConfig opus_decoder_config_ = {

--- a/iamf/cli/proto/codec_config.proto
+++ b/iamf/cli/proto/codec_config.proto
@@ -41,9 +41,7 @@ message OpusEncoderMetadata {
   optional OpusApplicationFlag application = 2;
   optional bool use_float_api = 3 [default = true];
   optional float coupling_rate_adjustment = 4 [default = 1.0];
-  optional bool use_substream_rate_override = 5 [default = false];
-  // so far the below uses substream_id as array index
-  repeated int32 substream_rate_overrides = 6 [packed = true];
+  map<uint32, int32> substream_id_to_bitrate_override = 5;
 }
 
 message OpusDecoderConfig {

--- a/iamf/cli/proto/codec_config.proto
+++ b/iamf/cli/proto/codec_config.proto
@@ -37,9 +37,18 @@ enum OpusApplicationFlag {
 
 // Settings to configure `libopus`.
 message OpusEncoderMetadata {
-  optional int32 target_bitrate_per_channel = 1;
   optional OpusApplicationFlag application = 2;
   optional bool use_float_api = 3 [default = true];
+
+  // Fields to control the bitrate.
+  //
+  //  - If the substream is present in `substream_id_to_bitrate_override`, the
+  //  bitrate override is used.
+  //  - Otherwise a bitrate is calculated based on the number of channels.
+  //    - One channel: `target_bitrate_per_channel`.
+  //    - Two channels: `target_bitrate_per_channel * 2 *
+  //  coupling_rate_adjustment`.
+  optional int32 target_bitrate_per_channel = 1;
   optional float coupling_rate_adjustment = 4 [default = 1.0];
   map<uint32, int32> substream_id_to_bitrate_override = 5;
 }

--- a/iamf/cli/proto/codec_config.proto
+++ b/iamf/cli/proto/codec_config.proto
@@ -41,6 +41,9 @@ message OpusEncoderMetadata {
   optional OpusApplicationFlag application = 2;
   optional bool use_float_api = 3 [default = true];
   optional float coupling_rate_adjustment = 4 [default = 1.0];
+  optional bool use_substream_rate_override = 5 [default = false];
+  // so far the below uses substream_id as array index
+  repeated int32 substream_rate_overrides = 6 [packed = true];
 }
 
 message OpusDecoderConfig {

--- a/iamf/cli/proto_to_obu/audio_frame_generator.cc
+++ b/iamf/cli/proto_to_obu/audio_frame_generator.cc
@@ -59,7 +59,7 @@ namespace {
 absl::Status InitializeEncoder(
     const iamf_tools_cli_proto::CodecConfig& codec_config_metadata,
     const CodecConfigObu& codec_config, int num_channels,
-    std::unique_ptr<EncoderBase>& encoder) {
+    std::unique_ptr<EncoderBase>& encoder, int substream_id = NULL) {
   switch (codec_config.GetCodecConfig().codec_id) {
     using enum CodecConfig::CodecId;
     case kCodecIdLpcm:
@@ -68,7 +68,7 @@ absl::Status InitializeEncoder(
     case kCodecIdOpus:
       encoder = std::make_unique<OpusEncoder>(
           codec_config_metadata.decoder_config_opus().opus_encoder_metadata(),
-          codec_config, num_channels);
+          codec_config, num_channels, substream_id);
       break;
     case kCodecIdAacLc:
       encoder = std::make_unique<AacEncoder>(
@@ -109,9 +109,9 @@ absl::Status GetEncodingDataAndInitializeEncoders(
           codec_config_obu.GetCodecConfigId()));
     }
 
-    RETURN_IF_NOT_OK(InitializeEncoder(codec_config_metadata_iter->second,
-                                       codec_config_obu, num_channels,
-                                       substream_id_to_encoder[substream_id]));
+    RETURN_IF_NOT_OK(InitializeEncoder(
+        codec_config_metadata_iter->second, codec_config_obu, num_channels,
+        substream_id_to_encoder[substream_id], substream_id));
   }
 
   return absl::OkStatus();

--- a/iamf/cli/proto_to_obu/audio_frame_generator.cc
+++ b/iamf/cli/proto_to_obu/audio_frame_generator.cc
@@ -59,7 +59,7 @@ namespace {
 absl::Status InitializeEncoder(
     const iamf_tools_cli_proto::CodecConfig& codec_config_metadata,
     const CodecConfigObu& codec_config, int num_channels,
-    std::unique_ptr<EncoderBase>& encoder, int substream_id = NULL) {
+    std::unique_ptr<EncoderBase>& encoder, int substream_id = 0) {
   switch (codec_config.GetCodecConfig().codec_id) {
     using enum CodecConfig::CodecId;
     case kCodecIdLpcm:


### PR DESCRIPTION
This is an experimental tool that is useful for sound quality optimization. Open to suggestions about the UI etc. Also, not sure if this would somehow be a hindrance and is better left out. 

Usage example in a .textproto config file:
```
codec_config_metadata {
  codec_config_id: 200
  codec_config {
    codec_id: CODEC_ID_OPUS
    num_samples_per_frame: 960
    audio_roll_distance: -4
    decoder_config_opus {
      version: 1
      pre_skip: 312
      input_sample_rate: 48000
      opus_encoder_metadata {
        target_bitrate_per_channel: 16000
        application: APPLICATION_AUDIO
        use_float_api: false
        use_substream_rate_override: true
        substream_rate_overrides: [64000, 57000, 30000, 9000]
      }
    }
  }
}
```