### PR TITLE
Removes quotes causing ffmpeg error

### DIFF
--- a/docs/external/encoding_with_external_tools.md
+++ b/docs/external/encoding_with_external_tools.md
@@ -49,7 +49,7 @@ ffmpeg -i /path/to/input.wav \
     -filter_complex "[0:a]channelmap=0|1:stereo[FRONT];[0:a]channelmap=4|5:stereo[BACK];[0:a]channelmap=2:mono[CENTER];[0:a]channelmap=3:mono[LFE]" \
     -map "[FRONT]" -map "[BACK]" -map "[CENTER]" -map "[LFE]" \
     -stream_group "type=iamf_audio_element:id=1:st=0:st=1:st=2:st=3:audio_element_type=channel,layer=ch_layout=5.1" \
-    -stream_group "type=iamf_mix_presentation:id=3:stg=0:annotations=en-us=default_mix_presentation,submix=parameter_id=100:parameter_rate=48000:default_mix_gain=0.0|element=stg=0:headphones_rendering_mode=binaural:annotations=en-us="5.1":parameter_id=101:parameter_rate=48000:default_mix_gain=0.0|layout=sound_system=stereo:integrated_loudness=0.0" \
+    -stream_group "type=iamf_mix_presentation:id=3:stg=0:annotations=en-us=default_mix_presentation,submix=parameter_id=100:parameter_rate=48000:default_mix_gain=0.0|element=stg=0:headphones_rendering_mode=binaural:annotations=en-us=5.1:parameter_id=101:parameter_rate=48000:default_mix_gain=0.0|layout=sound_system=stereo:integrated_loudness=0.0" \
     -streamid 0:0 -streamid 1:1 -streamid 2:2 -streamid 3:3 \
     -c:a libopus -b:a 64000 /path/to/output_iamf_or_mp4
 ```


### PR DESCRIPTION
With the quotes I get this error:

```shell

[AVFormatContext @ 000001d30b4600c0] Unable to choose an output format for '5.1\:parameter_id=101:parameter_rate=48000:default_mix_gain=0.0|layout=sound_system=stereo:integrated_loudness=0.0'; use a standard extension for the filename or specify the format manually.
[out#0 @ 000001d30ae90000] Error initializing the muxer for 5.1\:parameter_id=101:parameter_rate=48000:default_mix_gain=0.0|layout=sound_system=stereo:integrated_loudness=0.0: Invalid argument
Error opening output file 5.1\:parameter_id=101:parameter_rate=48000:default_mix_gain=0.0|layout=sound_system=stereo:integrated_loudness=0.0.
Error opening output files: Invalid argument

```