### PR TITLE
Security: Harden decoder against crafted bitstreams

### DIFF
--- a/iamf/cli/codec/aac_decoder.cc
+++ b/iamf/cli/codec/aac_decoder.cc
@@ -165,6 +165,13 @@ absl::StatusOr<std::unique_ptr<DecoderBase>> AacDecoder::Create(
     return status;
   }
 
+  // Constrain the maximum number of output channels to match the IAMF-level
+  // substream channel count.  Without this, fdk_aac's implicit SBR/PS
+  // processing could increase the output channel count beyond what the
+  // output buffer is sized for.
+  aacDecoder_SetParam(decoder, AAC_PCM_MAX_OUTPUT_CHANNELS,
+                      channel_count.num_channels());
+
   const auto* stream_info = aacDecoder_GetStreamInfo(decoder);
   ABSL_LOG_FIRST_N(INFO, 1) << "Created an AAC decoder with "
                             << stream_info->numChannels << " channels.";

--- a/iamf/cli/codec/flac_decoder.h
+++ b/iamf/cli/codec/flac_decoder.h
@@ -69,7 +69,8 @@ class FlacDecoder : public DecoderBase {
               FLAC__StreamDecoder* absl_nonnull decoder)
       : DecoderBase(channel_count, num_samples_per_frame), decoder_(decoder) {
     callback_data_ = std::make_unique<flac_callbacks::LibFlacCallbackData>(
-        num_samples_per_frame, decoded_samples_);
+        num_samples_per_frame, channel_count.num_channels(),
+        decoded_samples_);
   }
 
   // Backing data for the `libflac` decoder callbacks. Held in `unique_ptr` for

--- a/iamf/cli/codec/flac_decoder_stream_callbacks.cc
+++ b/iamf/cli/codec/flac_decoder_stream_callbacks.cc
@@ -72,6 +72,15 @@ FLAC__StreamDecoderWriteStatus LibFlacWriteCallback(
     return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
   }
 
+  // Reject frames whose channel count does not match the expected count from
+  // the IAMF codec config.  Without this check, a crafted FLAC frame could
+  // claim more channels than the downstream pipeline is sized for.
+  if (frame->header.channels != libflac_callback_data->num_channels_) {
+    ABSL_LOG(ERROR) << "Frame channel count " << frame->header.channels
+                    << " does not match expected " << libflac_callback_data->num_channels_;
+    return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
+  }
+
   auto& decoded_samples = libflac_callback_data->decoded_frame_;
   decoded_samples.resize(frame->header.channels);
   for (uint32_t c = 0; c < frame->header.channels; ++c) {

--- a/iamf/cli/codec/flac_decoder_stream_callbacks.h
+++ b/iamf/cli/codec/flac_decoder_stream_callbacks.h
@@ -42,9 +42,10 @@ class LibFlacCallbackData {
    *        time ticks within the function.
    */
   LibFlacCallbackData(
-      uint32_t num_samples_per_channel,
+      uint32_t num_samples_per_channel, uint32_t num_channels,
       std::vector<std::vector<InternalSampleType>>& decoded_frame)
       : num_samples_per_channel_(num_samples_per_channel),
+        num_channels_(num_channels),
         decoded_frame_(decoded_frame) {}
 
   /*!\brief Sets the frame to be decoded.
@@ -65,6 +66,7 @@ class LibFlacCallbackData {
   absl::Span<const uint8_t> GetNextSlice(size_t chunk_size);
 
   const uint32_t num_samples_per_channel_;
+  const uint32_t num_channels_;
 
   // Reference to the backing data for the decoded frame.
   std::vector<std::vector<InternalSampleType>>& decoded_frame_;

--- a/iamf/cli/codec/tests/flac_decoder_stream_callbacks_test.cc
+++ b/iamf/cli/codec/tests/flac_decoder_stream_callbacks_test.cc
@@ -36,14 +36,14 @@ using flac_callbacks::LibFlacCallbackData;
 
 TEST(LibFlacCallbackData, ConstructorSetsNumSamplesPerChannel) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
 
   EXPECT_EQ(callback_data.num_samples_per_channel_, kNumSamplesPerFrame);
 }
 
 TEST(LibFlacCallbackData, SetEncodedFrameRemovesPreviouslySetFrame) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   // Intentionally get the buffer to a state where it was partially exhausted.
   callback_data.SetEncodedFrame({99, 100});
   // Intentionally avoid exhausting the buffer.
@@ -57,7 +57,7 @@ TEST(LibFlacCallbackData, SetEncodedFrameRemovesPreviouslySetFrame) {
 
 TEST(LibFlacCallbackData, GetNextSliceCapsOutputToAtMostRemainingSize) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   const std::vector<uint8_t> kEncodedFrame = {99, 100};
   callback_data.SetEncodedFrame(kEncodedFrame);
 
@@ -69,7 +69,7 @@ TEST(LibFlacCallbackData, GetNextSliceCapsOutputToAtMostRemainingSize) {
 
 TEST(LibFlacCallbackData, RepeatedCallsToGetNextSliceReturnNextSlice) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   const std::vector<uint8_t> encoded_frame = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   callback_data.SetEncodedFrame(encoded_frame);
 
@@ -81,7 +81,7 @@ TEST(LibFlacCallbackData, RepeatedCallsToGetNextSliceReturnNextSlice) {
 
 TEST(LibFlacCallbackData, CallsWhenBufferIsExhaustedReturnEmptySpan) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   constexpr int kNumBytes = 5;
   const std::vector<uint8_t> encoded_frame(kNumBytes, 0);
   callback_data.SetEncodedFrame(encoded_frame);
@@ -93,7 +93,7 @@ TEST(LibFlacCallbackData, CallsWhenBufferIsExhaustedReturnEmptySpan) {
 TEST(LibFlacReadCallback, ReadCallbackReturnsEndOfStreamForEmptyFrame) {
   const std::vector<uint8_t> kEmptyFrame;
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   FLAC__byte buffer[1024];
   size_t bytes = 1024;
 
@@ -106,7 +106,7 @@ TEST(LibFlacReadCallback, ReadCallbackReturnsEndOfStreamForEmptyFrame) {
 
 TEST(LibFlacReadCallback, ReadCallbackReturnsAbortForNullPtrs) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   FLAC__byte buffer[1024];
   size_t bytes = 1024;
 
@@ -127,7 +127,7 @@ TEST(LibFlacReadCallback, ReadCallbackReturnsAbortForNullPtrs) {
 
 TEST(LibFlacReadCallback, EachCallToReadCallbackWritesUpToBufferSize) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   // Simulate `libFLAC` requestes 8 bytes at a time.
   const size_t kFlacBufferSize = 8;
   FLAC__byte buffer[kFlacBufferSize];
@@ -161,7 +161,7 @@ TEST(LibFlacReadCallback, EachCallToReadCallbackWritesUpToBufferSize) {
 
 TEST(LibFlacReadCallback, ConsumesEncodedFrame) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   FLAC__byte buffer[1024];
   size_t bytes = 1028;
   const std::vector<uint8_t> encoded_frame(1024, 1);
@@ -178,7 +178,7 @@ TEST(LibFlacReadCallback, ConsumesEncodedFrame) {
 
 TEST(LibFlacReadCallback, Success) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   FLAC__byte buffer[1024];
   size_t bytes = 1028;
   const std::vector<uint8_t> encoded_frame(1024, 1);
@@ -195,7 +195,7 @@ TEST(LibFlacReadCallback, Success) {
 TEST(LibFlacWriteCallback, SucceedsFor32BitSamples) {
   constexpr int kThreeSamplesPerFrame = 3;
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kThreeSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kThreeSamplesPerFrame, kNumChannels, decoded_frame);
   const FLAC__Frame kFlacFrame = {.header = {.blocksize = 3,
                                              .channels = kNumChannels,
                                              .bits_per_sample = 32}};
@@ -216,7 +216,7 @@ TEST(LibFlacWriteCallback, SucceedsFor32BitSamples) {
 TEST(LibFlacWriteCallback, SucceedsFor16BitSamples) {
   constexpr int kTwoSamplesPerFrame = 2;
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kTwoSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kTwoSamplesPerFrame, kNumChannels, decoded_frame);
   const FLAC__Frame kFlacFrame = {.header = {.blocksize = 2,
                                              .channels = kNumChannels,
                                              .bits_per_sample = 16}};
@@ -242,7 +242,7 @@ TEST(LibFlacWriteCallback, ReturnsStatusAbortForTooSmallBlockSize) {
   // num_samples_per_channel = 2, but the encoded frame has 3 samples per
   // channel.
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kTwoSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kTwoSamplesPerFrame, kNumChannels, decoded_frame);
   const FLAC__Frame kFlacFrame = {.header = {.blocksize = kLargerBlockSize,
                                              .channels = kNumChannels,
                                              .bits_per_sample = 32}};
@@ -262,7 +262,7 @@ TEST(LibFlacWriteCallback, FillsExtraSamplesWithZeros) {
   // num_samples_per_channel = 4, but the encoded frame has 3 samples per
   // channel.
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kFourSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kFourSamplesPerFrame, kNumChannels, decoded_frame);
   const FLAC__Frame kFlacFrame = {.header = {.blocksize = kSmallerBlockSize,
                                              .channels = kNumChannels,
                                              .bits_per_sample = 32}};
@@ -283,7 +283,7 @@ TEST(LibFlacWriteCallback, FillsExtraSamplesWithZeros) {
 
 TEST(LibFlacWriteCallback, ReturnsStatusAbortForInvalidBitsPerSampleMax) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   const uint32_t kInvalidBitsPerSample = 33;
   const FLAC__Frame kFlacFrame0 = {
       .header = {.blocksize = 1,
@@ -301,7 +301,7 @@ TEST(LibFlacWriteCallback, ReturnsStatusAbortForInvalidBitsPerSampleMax) {
 
 TEST(LibFlacWriteCallback, ReturnsStatusAbortForInvalidBitsPerSampleMin) {
   std::vector<std::vector<InternalSampleType>> decoded_frame;
-  LibFlacCallbackData callback_data(kNumSamplesPerFrame, decoded_frame);
+  LibFlacCallbackData callback_data(kNumSamplesPerFrame, kNumChannels, decoded_frame);
   const uint32_t kInvalidBitsPerSample = 15;
   const FLAC__Frame kFlacFrame0 = {
       .header = {.blocksize = 1,

--- a/iamf/cli/tests/audio_frame_decoder_test.cc
+++ b/iamf/cli/tests/audio_frame_decoder_test.cc
@@ -61,6 +61,13 @@ AudioFrameWithData PrepareEncodedAudioFrame(
       kAudioElementId, kCodecConfigId, {kSubstreamId}, codec_config_obus,
       audio_elements);
 
+  // The test FLAC frame (kFlacEncodedFrame) encodes stereo (left/side),
+  // so update the substream labels to match 2 channels.
+  if (codec_id_type == CodecConfig::kCodecIdFlac) {
+    audio_elements.at(kAudioElementId).substream_id_to_labels[kSubstreamId] =
+        {ChannelLabel::kL2, ChannelLabel::kR2};
+  }
+
   if (encoded_audio_frame_payload.empty()) {
     encoded_audio_frame_payload =
         std::vector<uint8_t>(kNumSamplesPerFrame * kBytesPerSample, 0);

--- a/iamf/obu/audio_element.cc
+++ b/iamf/obu/audio_element.cc
@@ -869,7 +869,11 @@ absl::Status AudioElementObu::ReadAndValidatePayloadDerived(
     audio_element_params_.push_back(std::move(audio_element_param));
   }
 
-  // Write the specific `audio_element_type`'s config.
+  // Validate that parameter definition types are unique before proceeding
+  // to the config-specific parsing (which returns directly from each case).
+  RETURN_IF_NOT_OK(ValidateUniqueParamDefinitionType(audio_element_params_));
+
+  // Read the specific `audio_element_type`'s config.
   switch (audio_element_type_) {
     case kAudioElementChannelBased:
       config_ = ScalableChannelLayoutConfig();
@@ -901,8 +905,6 @@ absl::Status AudioElementObu::ReadAndValidatePayloadDerived(
       return absl::OkStatus();
     }
   }
-  RETURN_IF_NOT_OK(ValidateUniqueParamDefinitionType(audio_element_params_));
-  return absl::OkStatus();
 }
 
 }  // namespace iamf_tools

--- a/iamf/obu/decoder_config/flac_decoder_config.cc
+++ b/iamf/obu/decoder_config/flac_decoder_config.cc
@@ -249,10 +249,17 @@ absl::Status FlacDecoderConfig::ReadAndValidate(uint32_t num_samples_per_frame,
 
   // We are not given a length field to indicate the number of metadata blocks
   // to read. Instead, we must look at the `last_metadata_block_flag` to
-  // determine when to stop reading.
+  // determine when to stop reading.  Cap at 128 blocks as a safety measure
+  // against crafted bitstreams — the FLAC spec defines only 7 block types.
+  static constexpr int kMaxMetadataBlocks = 128;
   std::vector<FlacMetadataBlock> metadata_blocks;
   bool last_metadata_block_flag = false;
+  int metadata_block_count = 0;
   while (!last_metadata_block_flag) {
+    if (++metadata_block_count > kMaxMetadataBlocks) {
+      return absl::InvalidArgumentError(
+          "Too many FLAC metadata blocks without last_metadata_block_flag.");
+    }
     FlacMetadataBlock metadata_block;
     RETURN_IF_NOT_OK(rb.ReadBoolean(last_metadata_block_flag));
     uint8_t block_type;

--- a/iamf/obu/metadata_obu.cc
+++ b/iamf/obu/metadata_obu.cc
@@ -9,6 +9,8 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "iamf/common/read_bit_buffer.h"
 #include "iamf/common/utils/macros.h"
 #include "iamf/common/write_bit_buffer.h"
@@ -19,14 +21,19 @@ namespace iamf_tools {
 
 namespace {
 
-uint64_t InferItuT35PayloadSize(const int64_t payload_size,
-                                const uint8_t metadata_type_size,
-                                bool has_country_code_extension_byte) {
+absl::StatusOr<uint64_t> InferItuT35PayloadSize(
+    const int64_t payload_size, const uint8_t metadata_type_size,
+    bool has_country_code_extension_byte) {
   // metadataTypeSize, 1 byte for the country code, and 1 byte for
   // the country code extension byte if present.
-  return has_country_code_extension_byte
-             ? payload_size - metadata_type_size - 2
-             : payload_size - metadata_type_size - 1;
+  const int64_t overhead =
+      metadata_type_size + (has_country_code_extension_byte ? 2 : 1);
+  if (payload_size < overhead) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "ITU-T T.35 payload_size= ", payload_size,
+        " is too small for the required overhead= ", overhead));
+  }
+  return static_cast<uint64_t>(payload_size - overhead);
 }
 
 absl::Status ReadAndValidateMetadataITUTT35(
@@ -41,10 +48,14 @@ absl::Status ReadAndValidateMetadataITUTT35(
     metadata_itu_t_t35.itu_t_t35_country_code_extension_byte =
         itu_t_t35_country_code_extension_byte;
   }
-  std::vector<uint8_t> temp_itu_t_t35_payload_bytes;
-  temp_itu_t_t35_payload_bytes.resize(InferItuT35PayloadSize(
+  auto inferred_size = InferItuT35PayloadSize(
       payload_size, metadata_type_size,
-      metadata_itu_t_t35.itu_t_t35_country_code == 0xFF));
+      metadata_itu_t_t35.itu_t_t35_country_code == 0xFF);
+  if (!inferred_size.ok()) {
+    return inferred_size.status();
+  }
+  std::vector<uint8_t> temp_itu_t_t35_payload_bytes;
+  temp_itu_t_t35_payload_bytes.resize(*inferred_size);
   RETURN_IF_NOT_OK(
       rb.ReadUint8Span(absl::MakeSpan(temp_itu_t_t35_payload_bytes)));
   metadata_itu_t_t35.itu_t_t35_payload_bytes =

--- a/iamf/obu/param_definitions/extended_param_definition.cc
+++ b/iamf/obu/param_definitions/extended_param_definition.cc
@@ -22,6 +22,7 @@
 #include "iamf/common/write_bit_buffer.h"
 #include "iamf/obu/extension_parameter_data.h"
 #include "iamf/obu/parameter_data.h"
+#include "absl/strings/str_cat.h"
 #include "iamf/obu/types.h"
 
 namespace iamf_tools {
@@ -42,6 +43,10 @@ absl::Status ExtendedParamDefinition::ReadAndValidate(ReadBitBuffer& rb) {
   // `ParamDefinition::ReadAndWrite(wb)`.
   DecodedUleb128 param_definition_size;
   RETURN_IF_NOT_OK(rb.ReadULeb128(param_definition_size));
+  if (param_definition_size > kEntireObuSizeMaxTwoMegabytes) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "param_definition_size= ", param_definition_size, " exceeds maximum."));
+  }
   param_definition_bytes_.resize(param_definition_size);
   RETURN_IF_NOT_OK(rb.ReadUint8Span(absl::MakeSpan(param_definition_bytes_)));
 

--- a/iamf/obu/param_definitions/param_definition_base.cc
+++ b/iamf/obu/param_definitions/param_definition_base.cc
@@ -144,6 +144,10 @@ absl::Status ParamDefinition::ReadAndValidate(ReadBitBuffer& rb) {
 
   // Loop to read the `subblock_durations` array if it should be included.
   RETURN_IF_NOT_OK(rb.ReadULeb128(num_subblocks_));
+  if (num_subblocks_ > kEntireObuSizeMaxTwoMegabytes) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("num_subblocks= ", num_subblocks_, " exceeds maximum."));
+  }
   for (DecodedUleb128 i = 0; i < num_subblocks_; i++) {
     DecodedUleb128 subblock_duration;
     RETURN_IF_NOT_OK(rb.ReadULeb128(subblock_duration));


### PR DESCRIPTION
## Summary

Batch of security hardening patches for the IAMF decoder to prevent DoS and potential memory safety issues from malicious bitstreams. These were identified through a security-focused code review of the decoder pipeline.

## Changes

### Memory Safety (High Impact)

1. **AAC: Set `AAC_PCM_MAX_OUTPUT_CHANNELS`** (`aac_decoder.cc`)
   - fdk_aac's implicit SBR/PS processing can increase output channels beyond what the buffer is sized for
   - Confirmed via testing: feeding HE-AACv2 (PS) encoded frames to a mono-configured decoder produces 2-channel output
   - The fix constrains fdk_aac to match the IAMF substream channel count

2. **FLAC: Validate frame channel count** (`flac_decoder_stream_callbacks.cc/.h`, `flac_decoder.h`)
   - libflac can report up to 8 channels from a crafted FLAC frame header
   - The write callback previously resized output vectors to match the frame's channel count without checking against the expected count
   - Added `num_channels_` field to `LibFlacCallbackData` and validation in the callback

3. **ITU-T T.35 metadata: Fix integer underflow** (`metadata_obu.cc`)
   - `InferItuT35PayloadSize()` subtracted fixed overhead from `payload_size` without checking the result
   - A small `payload_size` wraps the `uint64_t` return to ~18 exabytes, causing `std::bad_alloc` on `resize()`
   - Changed return type to `absl::StatusOr<uint64_t>` with proper bounds checking

### DoS Prevention (Medium Impact)

4. **FLAC metadata blocks: Cap loop iterations** (`flac_decoder_config.cc`)
   - The `while(!last_metadata_block_flag)` loop had no iteration limit
   - A crafted codec config could cause unbounded allocation (16MB per block via 24-bit length field)
   - Added cap of 128 blocks (FLAC spec defines only 7 block types)

5. **Unbounded allocations: Cap parsed sizes** (`param_definition_base.cc`, `extended_param_definition.cc`)
   - `num_subblocks` and `param_definition_size` are ULEB128 values parsed from the bitstream (up to UINT32_MAX)
   - Added validation against `kEntireObuSizeMaxTwoMegabytes` before `resize()`

### Correctness

6. **Fix unreachable validation** (`audio_element.cc`)
   - `ValidateUniqueParamDefinitionType()` was placed after a switch statement where every case returned directly
   - Moved before the switch so it actually executes during decoding

## Testing

- All patches compile with `bazel build //iamf/cli:decoder_main`
- Verified the decoder still decodes valid FLAC, Opus, and PCM test vectors correctly
- The AAC PS channel mismatch was confirmed via a test program that encodes stereo with HE-AACv2, then decodes with a mono-configured decoder — fdk_aac outputs 2 channels from mono config

## Motivation

These issues were found during a security audit of iamf-tools as the production IAMF decoder used on Android devices (via `libcodec2_soft_iamfdec.so`). While the 2MB OBU size limit and `ReadBitBuffer` bounds checking provide significant defense in depth, these patches address gaps where parsed values bypass those protections.