### PR TITLE
Bound ULEB128-derived allocation sizes in RenderingConfig and ElementGainOffsetConfig

### DIFF
--- a/iamf/obu/BUILD
+++ b/iamf/obu/BUILD
@@ -184,6 +184,7 @@ cc_library(
     srcs = ["element_gain_offset_config.cc"],
     hdrs = ["element_gain_offset_config.h"],
     deps = [
+        ":types",
         "//iamf/common:q_format_or_floating_point",
         "//iamf/common:read_bit_buffer",
         "//iamf/common:write_bit_buffer",

--- a/iamf/obu/element_gain_offset_config.cc
+++ b/iamf/obu/element_gain_offset_config.cc
@@ -19,6 +19,7 @@
 #include "absl/log/absl_log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "iamf/common/q_format_or_floating_point.h"
@@ -26,6 +27,7 @@
 #include "iamf/common/utils/macros.h"
 #include "iamf/common/utils/validation_utils.h"
 #include "iamf/common/write_bit_buffer.h"
+#include "iamf/obu/types.h"
 
 namespace iamf_tools {
 
@@ -155,6 +157,11 @@ ElementGainOffsetConfig::CreateFromBuffer(ReadBitBuffer& rb) {
   // Else it is an extension type.
   uint32_t element_gain_offset_size;
   RETURN_IF_NOT_OK(rb.ReadULeb128(element_gain_offset_size));
+  if (element_gain_offset_size > kEntireObuSizeMaxTwoMegabytes) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "element_gain_offset_size= ", element_gain_offset_size,
+        " exceeds maximum."));
+  }
   std::vector<uint8_t> element_gain_offset_bytes(element_gain_offset_size);
   RETURN_IF_NOT_OK(rb.ReadUint8Span(MakeSpan(element_gain_offset_bytes)));
   return CreateExtensionType(element_gain_offset_config_type,

--- a/iamf/obu/rendering_config.cc
+++ b/iamf/obu/rendering_config.cc
@@ -258,6 +258,11 @@ absl::StatusOr<RenderingConfig> RenderingConfig::CreateFromBuffer(
   RETURN_IF_NOT_OK(rb.ReadUnsignedLiteral(3, reserved));
   DecodedUleb128 rendering_config_extension_size;
   RETURN_IF_NOT_OK(rb.ReadULeb128(rendering_config_extension_size));
+  if (rendering_config_extension_size > kEntireObuSizeMaxTwoMegabytes) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "rendering_config_extension_size= ", rendering_config_extension_size,
+        " exceeds maximum."));
+  }
   if (rendering_config_extension_size == 0) {
     return RenderingConfig{
         .headphones_rendering_mode = headphones_rendering_mode_enum,


### PR DESCRIPTION
## Summary

- Add bounds checks against `kEntireObuSizeMaxTwoMegabytes` before ULEB128-sized vector allocations in `RenderingConfig::CreateFromBuffer()` and `ElementGainOffsetConfig::CreateFromBuffer()`
- Prevents OOM process crash from crafted IAMF bitstreams with large extension size values
- Follows the existing bounds-checking pattern used in `extended_param_definition.cc` and `param_definition_base.cc`

## Problem

`rendering_config_extension_size` and `element_gain_offset_size` are read as ULEB128 values from the bitstream and passed directly to `std::vector` constructors with no upper bound. A 5-byte ULEB128 encoding can request up to ~4 GB, causing `std::bad_alloc` → `std::terminate` → process crash.

**Affected sites:**
| File | Line | Variable |
|------|------|----------|
| `rendering_config.cc` | 298 | `rendering_config_extension_size` → `vector<uint8_t>(N)` |
| `element_gain_offset_config.cc` | 158 | `element_gain_offset_size` → `vector<uint8_t>(N)` |

## Fix

Check against the existing `kEntireObuSizeMaxTwoMegabytes` (2 MB) constant before allocating, returning `InvalidArgumentError` for oversized values. This is the same pattern used at:
- `extended_param_definition.cc:46`
- `param_definition_base.cc:147`

## Test plan

- [ ] Existing unit tests pass (`bazelisk test //iamf/obu/...`)
- [ ] Verified crafted IAMF bitstream with `rendering_config_extension_size = 0x3FFFFFFF` now returns error instead of OOM crash
- [ ] Verified crafted IAMF bitstream with large `element_gain_offset_size` now returns error instead of OOM crash