### PR TITLE
Accept canonical IA Sequence Header following a redundant copy

### DIFF
--- a/iamf/cli/descriptor_obu_parser.cc
+++ b/iamf/cli/descriptor_obu_parser.cc
@@ -154,6 +154,11 @@ absl::StatusOr<DescriptorObus> DescriptorObuParser::ProcessDescriptorObus(
   DescriptorObus parsed_obus;
   const int64_t global_position_before_all_obus = read_bit_buffer.Tell();
   bool processed_ia_header = false;
+  // Tracks whether the stored IA Sequence Header is a redundant copy. If so,
+  // a subsequent non-redundant header before any temporal unit is treated as
+  // the canonical header (it overrides the redundant one) rather than the
+  // start of a new sequence.
+  bool stored_ia_header_is_redundant = false;
   bool continue_processing = true;
   while (continue_processing) {
     auto header_metadata =
@@ -215,7 +220,8 @@ absl::StatusOr<DescriptorObus> DescriptorObuParser::ProcessDescriptorObus(
     absl::Status parsed_obu_status = absl::OkStatus();
     switch (header.obu_type) {
       case kObuIaSequenceHeader: {
-        if (processed_ia_header && !header.obu_redundant_copy) {
+        if (processed_ia_header && !header.obu_redundant_copy &&
+            !stored_ia_header_is_redundant) {
           ABSL_LOG(WARNING)
               << "Detected an IA Sequence without temporal units.";
           continue_processing = false;
@@ -229,6 +235,7 @@ absl::StatusOr<DescriptorObus> DescriptorObuParser::ProcessDescriptorObus(
         parsed_obus.ia_sequence_header = *std::move(ia_sequence_header_obu);
         parsed_obus.ia_sequence_header.PrintObu();
         processed_ia_header = true;
+        stored_ia_header_is_redundant = header.obu_redundant_copy;
         break;
       }
       case kObuIaCodecConfig:

--- a/iamf/cli/tests/descriptor_obu_parser_test.cc
+++ b/iamf/cli/tests/descriptor_obu_parser_test.cc
@@ -262,6 +262,39 @@ TEST(ProcessDescriptorObus, SucceedsWithSuccessiveRedundantSequenceHeaders) {
   EXPECT_FALSE(insufficient_data);
 }
 
+TEST(ProcessDescriptorObus, RedundantSequenceHeaderBeforeCanonicalIsReplaced) {
+  // An out-of-spec ordering observed in the test corpus: a redundant-copy
+  // IA Sequence Header is inserted *before* the canonical one. The parser
+  // must accept the canonical header (replacing the stored redundant copy)
+  // and continue collecting the descriptor OBUs that follow it.
+  const IASequenceHeaderObu input_redundant_ia_sequence_header(
+      ObuHeader{.obu_redundant_copy = true}, ProfileVersion::kIamfBaseProfile,
+      ProfileVersion::kIamfBaseProfile);
+  const IASequenceHeaderObu input_canonical_ia_sequence_header(
+      ObuHeader(), ProfileVersion::kIamfSimpleProfile,
+      ProfileVersion::kIamfBaseProfile);
+  CodecConfigsById input_codec_configs;
+  AddOpusCodecConfigWithId(kFirstCodecConfigId, input_codec_configs);
+  const auto bitstream = SerializeObusExpectOk(
+      {&input_redundant_ia_sequence_header, &input_canonical_ia_sequence_header,
+       &input_codec_configs.at(kFirstCodecConfigId)});
+
+  auto read_bit_buffer =
+      MemoryBasedReadBitBuffer::CreateFromSpan(absl::MakeConstSpan(bitstream));
+  bool insufficient_data;
+  auto parsed_obus = DescriptorObuParser::ProcessDescriptorObus(
+      /*is_exhaustive_and_exact=*/true, *read_bit_buffer, insufficient_data);
+  ASSERT_THAT(parsed_obus, IsOk());
+  EXPECT_FALSE(insufficient_data);
+
+  // Stored header is the canonical one — the redundant copy was overridden.
+  EXPECT_EQ(parsed_obus->ia_sequence_header.GetPrimaryProfile(),
+            ProfileVersion::kIamfSimpleProfile);
+  // And the codec config that came after the canonical header was collected.
+  EXPECT_THAT(parsed_obus->codec_config_obus,
+              UnorderedElementsAre(Key(kFirstCodecConfigId)));
+}
+
 TEST(ProcessDescriptorObus, ConsumesUpToNextNonRedundantSequenceHeader) {
   const IASequenceHeaderObu input_non_redundant_ia_sequence_header(
       ObuHeader(), ProfileVersion::kIamfSimpleProfile,


### PR DESCRIPTION
## Summary

The descriptor parser previously bailed with `IA Sequence without temporal units` when a non-redundant IA Sequence Header arrived after a stored header that was itself a redundant copy. That ordering is out of spec, but it appears in files in the wild (e.g. test corpus file `test_000079`, which injects a redundant copy before the canonical header via `arbitrary_obu_metadata`). The result was that all descriptor OBUs following the canonical header were dropped and the whole sequence was rejected, even though it is otherwise decodable.

This change tracks whether the stored header was a redundant copy. If it was, the next non-redundant header replaces it and parsing continues, instead of being treated as the start of a new IA Sequence. The original safety check still triggers when the stored header was canonical, so legitimate sequence boundaries continue to be respected.

## Test plan

- New test `RedundantSequenceHeaderBeforeCanonicalIsReplaced` in `descriptor_obu_parser_test.cc` reconstructs the out-of-spec ordering (redundant copy, then canonical header, then a codec config) and verifies the parser accepts the canonical header and keeps the descriptor OBUs that follow.
- `bazel test //iamf/cli/tests:descriptor_obu_parser_test` passes.