### PR TITLE
Add a descriptor-OBU probe tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ standalone IAMF and IAMF in MP4.
 -   [`IamfDecoderInterface` API](docs/iamf_decoder_interface.md)
 -   [Command-line decoder for standalone IAMF files](docs/iamf_decoder_main.md)
 
+### Inspecting IAMF content
+
+`iamf-tools` provides a probe that summarizes the descriptor OBUs (and,
+optionally, the temporal units) of a standalone IAMF file without decoding
+any audio:
+
+-   [`Probe` API](iamf/cli/probe.h)
+-   [Command-line probe for standalone IAMF files](docs/iamf_probe_main.md)
+
 ### Web Demo
 
 The [web demo](https://aomediacodec.github.io/iamf-tools/web_demo/) hosted in

--- a/docs/iamf_probe_main.md
+++ b/docs/iamf_probe_main.md
@@ -1,0 +1,78 @@
+# Probe
+
+`iamf-tools` provides a command-line probe that summarizes the contents of a
+standalone IAMF sequence (`.iamf`) file without decoding any audio. It prints
+the descriptor OBUs — IA Sequence Header profiles, Codec Configs, Audio
+Elements, and Mix Presentations (including loudness annotations and tags) —
+and can optionally walk the temporal units to report parameter-block
+contents, per-substream sample totals, and the stream duration.
+
+The probe is useful for inspecting files produced by the encoder, debugging
+malformed or truncated streams, and building tooling that needs IAMF metadata
+without a full decode.
+
+The underlying C++ API is `iamf_tools::Probe()` in
+[`iamf/cli/probe.h`](../iamf/cli/probe.h), which returns the same data as a
+structured `ProbeReport`.
+
+## Building the probe
+
+See [Build instructions](build_instructions.md) to build from source, then:
+
+```
+bazel build -c opt //iamf/cli:probe_main
+```
+
+## Using the probe
+
+The input file may be passed as a positional argument, via
+`--input_filename`, or as `-` to read the stream from stdin:
+
+```
+probe_main input.iamf
+probe_main --input_filename=input.iamf
+cat input.iamf | probe_main -
+```
+
+Pointing the probe at an MP4 file (IAMF usually travels inside MP4), or at a
+stream that starts mid-sequence, produces an error explaining the problem.
+
+Optional flags:
+
+-   `--format` Output format: `text` (default, a human-readable summary) or
+    `json`.
+-   `--scan` Temporal-unit scan mode: `counts` or `full`. `counts` walks the
+    temporal units after the descriptor OBUs and reports OBU counts,
+    per-substream sample totals, and the overall duration; the report size
+    stays independent of the stream length, so use it for duration-only
+    probes of large files. `full` additionally reports parameter-block
+    contents (mix-gain animations, demixing info, recon gain) and a
+    per-temporal-unit index. By default no scan runs: only descriptor OBUs
+    are parsed, so probing is fast even on very large files.
+-   `--duration` Shorthand for `--scan=counts`.
+
+Example:
+
+```
+bazel-bin/iamf/cli/probe_main iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf
+```
+
+This prints a human-readable report of the file's descriptor OBUs to stdout
+(pass `--format=json` for machine-readable output). To also compute the
+duration of a large file as cheaply as possible:
+
+```
+bazel-bin/iamf/cli/probe_main \
+  --input_filename=input.iamf \
+  --duration
+```
+
+## Robustness
+
+The descriptor parse is strict: the probe reports an error if the input does
+not begin with a valid IAMF descriptor sequence. The temporal-unit scan is
+best-effort in the spirit of the specification: OBUs that fail to parse are
+counted (`audio_frame_parse_errors`, `parameter_block_parse_errors`) and
+skipped, and the report's `stopped_reason` records why the scan ended (`eof`,
+`truncated`, `malformed`, `next_ia_sequence`, or `scan_budget_exceeded`), so
+a healthy file can be distinguished from a damaged one.

--- a/iamf/cli/BUILD
+++ b/iamf/cli/BUILD
@@ -580,6 +580,55 @@ cc_library(
 )
 
 cc_library(
+    name = "probe",
+    srcs = ["probe.cc"],
+    hdrs = ["probe.h"],
+    deps = [
+        ":audio_element_with_data",
+        ":cli_util",
+        ":descriptor_obu_parser",
+        ":descriptor_obus",
+        "//iamf/common:read_bit_buffer",
+        "//iamf/obu:audio_element",
+        "//iamf/obu:codec_config",
+        "//iamf/obu:ia_sequence_header",
+        "//iamf/obu:mix_presentation",
+        "//iamf/obu:obu_header",
+        "//iamf/obu:parameter_block",
+        "//iamf/obu:parameter_data",
+        "//iamf/obu:rendering_config",
+        "//iamf/obu:types",
+        "//iamf/obu/decoder_config:aac_decoder_config",
+        "//iamf/obu/decoder_config:flac_decoder_config",
+        "//iamf/obu/decoder_config:lpcm_decoder_config",
+        "//iamf/obu/decoder_config:opus_decoder_config",
+        "//iamf/obu/param_definitions:demixing_param_definition",
+        "//iamf/obu/param_definitions:extended_param_definition",
+        "//iamf/obu/param_definitions:param_definition_base",
+        "//iamf/obu/param_definitions:param_definition_variant",
+        "//iamf/obu/param_definitions:recon_gain_param_definition",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/log:absl_log",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "probe_json",
+    srcs = ["probe_json.cc"],
+    hdrs = ["probe_json.h"],
+    deps = [
+        ":probe",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+    ],
+)
+
+cc_library(
     name = "profile_filter",
     srcs = ["profile_filter.cc"],
     hdrs = ["profile_filter.h"],
@@ -825,6 +874,24 @@ cc_binary(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@protobuf",
+    ],
+)
+
+cc_binary(
+    name = "probe_main",
+    srcs = ["probe_main.cc"],
+    deps = [
+        ":probe",
+        ":probe_json",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/flags:parse",
+        "@abseil-cpp//absl/flags:usage",
+        "@abseil-cpp//absl/log:globals",
+        "@abseil-cpp//absl/log:initialize",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@abseil-cpp//absl/types:span",
     ],
 )
 

--- a/iamf/cli/probe.cc
+++ b/iamf/cli/probe.cc
@@ -1,0 +1,1434 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#include "iamf/cli/probe.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/absl_log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "iamf/cli/audio_element_with_data.h"
+#include "iamf/cli/cli_util.h"
+#include "iamf/cli/descriptor_obu_parser.h"
+#include "iamf/cli/descriptor_obus.h"
+#include "iamf/common/read_bit_buffer.h"
+#include "iamf/obu/audio_element.h"
+#include "iamf/obu/codec_config.h"
+#include "iamf/obu/decoder_config/aac_decoder_config.h"
+#include "iamf/obu/decoder_config/flac_decoder_config.h"
+#include "iamf/obu/decoder_config/lpcm_decoder_config.h"
+#include "iamf/obu/decoder_config/opus_decoder_config.h"
+#include "iamf/obu/demixing_info_parameter_data.h"
+#include "iamf/obu/ia_sequence_header.h"
+#include "iamf/obu/mix_gain_parameter_data.h"
+#include "iamf/obu/mix_presentation.h"
+#include "iamf/obu/obu_header.h"
+#include "iamf/obu/param_definitions/demixing_param_definition.h"
+#include "iamf/obu/param_definitions/extended_param_definition.h"
+#include "iamf/obu/param_definitions/param_definition_base.h"
+#include "iamf/obu/param_definitions/param_definition_variant.h"
+#include "iamf/obu/param_definitions/recon_gain_param_definition.h"
+#include "iamf/obu/parameter_block.h"
+#include "iamf/obu/recon_gain_info_parameter_data.h"
+#include "iamf/obu/rendering_config.h"
+#include "iamf/obu/types.h"
+
+namespace iamf_tools {
+
+namespace {
+
+// ---------- Enum to string helpers ----------
+
+std::string ProfileToString(ProfileVersion profile) {
+  switch (profile) {
+    case ProfileVersion::kIamfSimpleProfile:
+      return "simple";
+    case ProfileVersion::kIamfBaseProfile:
+      return "base";
+    case ProfileVersion::kIamfBaseEnhancedProfile:
+      return "base_enhanced";
+    case ProfileVersion::kIamfBaseAdvancedProfile:
+      return "base_advanced";
+    case ProfileVersion::kIamfAdvanced1Profile:
+      return "advanced1";
+    case ProfileVersion::kIamfAdvanced2Profile:
+      return "advanced2";
+    case ProfileVersion::kIamfReserved255Profile:
+      return "reserved_255";
+  }
+  return absl::StrCat("unknown(", static_cast<int>(profile), ")");
+}
+
+std::string CodecIdToString(CodecConfig::CodecId id) {
+  switch (id) {
+    case CodecConfig::kCodecIdOpus:
+      return "Opus";
+    case CodecConfig::kCodecIdFlac:
+      return "FLAC";
+    case CodecConfig::kCodecIdLpcm:
+      return "LPCM";
+    case CodecConfig::kCodecIdAacLc:
+      return "AAC LC";
+  }
+  char cc[5] = {
+      static_cast<char>((id >> 24) & 0xff),
+      static_cast<char>((id >> 16) & 0xff),
+      static_cast<char>((id >> 8) & 0xff),
+      static_cast<char>(id & 0xff),
+      0,
+  };
+  return absl::StrCat("unknown(", cc, ")");
+}
+
+std::string AudioElementTypeToString(AudioElementObu::AudioElementType t) {
+  switch (t) {
+    case AudioElementObu::kAudioElementChannelBased:
+      return "channel_based";
+    case AudioElementObu::kAudioElementSceneBased:
+      return "scene_based";
+    case AudioElementObu::kAudioElementObjectBased:
+      return "object_based";
+    default:
+      return absl::StrCat("reserved(", static_cast<int>(t), ")");
+  }
+}
+
+std::string LoudspeakerLayoutToString(
+    ChannelAudioLayerConfig::LoudspeakerLayout layout) {
+  switch (layout) {
+    case ChannelAudioLayerConfig::kLayoutMono:
+      return "Mono";
+    case ChannelAudioLayerConfig::kLayoutStereo:
+      return "Stereo";
+    case ChannelAudioLayerConfig::kLayout5_1_ch:
+      return "5.1";
+    case ChannelAudioLayerConfig::kLayout5_1_2_ch:
+      return "5.1.2";
+    case ChannelAudioLayerConfig::kLayout5_1_4_ch:
+      return "5.1.4";
+    case ChannelAudioLayerConfig::kLayout7_1_ch:
+      return "7.1";
+    case ChannelAudioLayerConfig::kLayout7_1_2_ch:
+      return "7.1.2";
+    case ChannelAudioLayerConfig::kLayout7_1_4_ch:
+      return "7.1.4";
+    case ChannelAudioLayerConfig::kLayout3_1_2_ch:
+      return "3.1.2";
+    case ChannelAudioLayerConfig::kLayoutBinaural:
+      return "Binaural";
+    case ChannelAudioLayerConfig::kLayoutExpanded:
+      return "Expanded";
+    default:
+      return absl::StrCat("reserved(", static_cast<int>(layout), ")");
+  }
+}
+
+std::string ExpandedLayoutToString(
+    ChannelAudioLayerConfig::ExpandedLoudspeakerLayout layout) {
+  using E = ChannelAudioLayerConfig;
+  switch (layout) {
+    case E::kExpandedLayoutLFE:
+      return "LFE";
+    case E::kExpandedLayoutStereoS:
+      return "StereoS";
+    case E::kExpandedLayoutStereoSS:
+      return "StereoSS";
+    case E::kExpandedLayoutStereoRS:
+      return "StereoRS";
+    case E::kExpandedLayoutStereoTF:
+      return "StereoTF";
+    case E::kExpandedLayoutStereoTB:
+      return "StereoTB";
+    case E::kExpandedLayoutTop4Ch:
+      return "Top4Ch";
+    case E::kExpandedLayout3_0_ch:
+      return "3.0";
+    case E::kExpandedLayout9_1_6_ch:
+      return "9.1.6";
+    case E::kExpandedLayoutStereoF:
+      return "StereoF";
+    case E::kExpandedLayoutStereoSi:
+      return "StereoSi";
+    case E::kExpandedLayoutStereoTpSi:
+      return "StereoTpSi";
+    case E::kExpandedLayoutTop6Ch:
+      return "Top6Ch";
+    case E::kExpandedLayout10_2_9_3:
+      return "10.2.9.3";
+    case E::kExpandedLayoutLfePair:
+      return "LfePair";
+    case E::kExpandedLayoutBottom3Ch:
+      return "Bottom3Ch";
+    case E::kExpandedLayout7_1_5_4Ch:
+      return "7.1.5.4";
+    case E::kExpandedLayoutBottom4Ch:
+      return "Bottom4Ch";
+    case E::kExpandedLayoutTop1Ch:
+      return "Top1Ch";
+    case E::kExpandedLayoutTop5Ch:
+      return "Top5Ch";
+    default:
+      return absl::StrCat("reserved(", static_cast<int>(layout), ")");
+  }
+}
+
+std::string SoundSystemToString(
+    LoudspeakersSsConventionLayout::SoundSystem ss) {
+  switch (ss) {
+    case LoudspeakersSsConventionLayout::kSoundSystemA_0_2_0:
+      return "Stereo";
+    case LoudspeakersSsConventionLayout::kSoundSystemB_0_5_0:
+      return "5.1";
+    case LoudspeakersSsConventionLayout::kSoundSystemC_2_5_0:
+      return "5.1.2";
+    case LoudspeakersSsConventionLayout::kSoundSystemD_4_5_0:
+      return "5.1.4";
+    case LoudspeakersSsConventionLayout::kSoundSystemE_4_5_1:
+      return "5+4+1";
+    case LoudspeakersSsConventionLayout::kSoundSystemF_3_7_0:
+      return "3+7+0";
+    case LoudspeakersSsConventionLayout::kSoundSystemG_4_9_0:
+      return "9.1.4";
+    case LoudspeakersSsConventionLayout::kSoundSystemH_9_10_3:
+      return "22.2";
+    case LoudspeakersSsConventionLayout::kSoundSystemI_0_7_0:
+      return "7.1";
+    case LoudspeakersSsConventionLayout::kSoundSystemJ_4_7_0:
+      return "7.1.4";
+    case LoudspeakersSsConventionLayout::kSoundSystem10_2_7_0:
+      return "7.1.2";
+    case LoudspeakersSsConventionLayout::kSoundSystem11_2_3_0:
+      return "3.1.2";
+    case LoudspeakersSsConventionLayout::kSoundSystem12_0_1_0:
+      return "Mono";
+    case LoudspeakersSsConventionLayout::kSoundSystem13_6_9_0:
+      return "9.1.6";
+    case LoudspeakersSsConventionLayout::kSoundSystem14_5_7_4:
+      return "7.1.5.4";
+    default:
+      return absl::StrCat("reserved(", static_cast<int>(ss), ")");
+  }
+}
+
+std::string LayoutTypeToString(Layout::LayoutType t) {
+  switch (t) {
+    case Layout::kLayoutTypeLoudspeakersSsConvention:
+      return "loudspeakers_ss_convention";
+    case Layout::kLayoutTypeBinaural:
+      return "binaural";
+    case Layout::kLayoutTypeReserved0:
+      return "reserved_0";
+    case Layout::kLayoutTypeReserved1:
+      return "reserved_1";
+  }
+  return absl::StrCat("reserved(", static_cast<int>(t), ")");
+}
+
+std::string HeadphonesRenderingModeToString(
+    RenderingConfig::HeadphonesRenderingMode m) {
+  switch (m) {
+    case RenderingConfig::kHeadphonesRenderingModeStereo:
+      return "stereo";
+    case RenderingConfig::kHeadphonesRenderingModeBinauralWorldLocked:
+      return "binaural_world_locked";
+    case RenderingConfig::kHeadphonesRenderingModeBinauralHeadLocked:
+      return "binaural_head_locked";
+    case RenderingConfig::kHeadphonesRenderingModeReserved3:
+      return "reserved_3";
+  }
+  return absl::StrCat("reserved(", static_cast<int>(m), ")");
+}
+
+std::string BinauralFilterProfileToString(
+    RenderingConfig::BinauralFilterProfile p) {
+  switch (p) {
+    case RenderingConfig::kBinauralFilterProfileAmbient:
+      return "ambient";
+    case RenderingConfig::kBinauralFilterProfileDirect:
+      return "direct";
+    case RenderingConfig::kBinauralFilterProfileReverberant:
+      return "reverberant";
+    case RenderingConfig::kBinauralFilterProfileReserved3:
+      return "reserved_3";
+  }
+  return absl::StrCat("reserved(", static_cast<int>(p), ")");
+}
+
+std::string AnchorElementToString(AnchoredLoudnessElement::AnchorElement a) {
+  switch (a) {
+    case AnchoredLoudnessElement::kAnchorElementUnknown:
+      return "unknown";
+    case AnchoredLoudnessElement::kAnchorElementDialogue:
+      return "dialogue";
+    case AnchoredLoudnessElement::kAnchorElementAlbum:
+      return "album";
+  }
+  return absl::StrCat("reserved(", static_cast<int>(a), ")");
+}
+
+std::string LpcmSampleFormatToString(
+    LpcmDecoderConfig::LpcmFormatFlagsBitmask f) {
+  if ((f & LpcmDecoderConfig::kLpcmLittleEndian) != 0) return "little_endian";
+  if (f == LpcmDecoderConfig::kLpcmBigEndian) return "big_endian";
+  return absl::StrCat("reserved(", static_cast<int>(f), ")");
+}
+
+std::string AacSampleFrequencyIndexToString(
+    AudioSpecificConfig::SampleFrequencyIndex i) {
+  using E = AudioSpecificConfig::SampleFrequencyIndex;
+  switch (i) {
+    case E::k96000:
+      return "96000";
+    case E::k88200:
+      return "88200";
+    case E::k64000:
+      return "64000";
+    case E::k48000:
+      return "48000";
+    case E::k44100:
+      return "44100";
+    case E::k32000:
+      return "32000";
+    case E::k24000:
+      return "24000";
+    case E::k22050:
+      return "22050";
+    case E::k16000:
+      return "16000";
+    case E::k12000:
+      return "12000";
+    case E::k11025:
+      return "11025";
+    case E::k8000:
+      return "8000";
+    case E::k7350:
+      return "7350";
+    case E::kReservedA:
+      return "reserved_a";
+    case E::kReservedB:
+      return "reserved_b";
+  }
+  return absl::StrCat("reserved(", static_cast<int>(i), ")");
+}
+
+std::string ParamDefinitionTypeToString(
+    ParamDefinition::ParameterDefinitionType t) {
+  switch (t) {
+    case ParamDefinition::kParameterDefinitionMixGain:
+      return "mix_gain";
+    case ParamDefinition::kParameterDefinitionDemixing:
+      return "demixing";
+    case ParamDefinition::kParameterDefinitionReconGain:
+      return "recon_gain";
+    case ParamDefinition::kParameterDefinitionPolar:
+      return "polar";
+    case ParamDefinition::kParameterDefinitionCart8:
+      return "cart8";
+    case ParamDefinition::kParameterDefinitionCart16:
+      return "cart16";
+    case ParamDefinition::kParameterDefinitionDualPolar:
+      return "dual_polar";
+    case ParamDefinition::kParameterDefinitionDualCart8:
+      return "dual_cart8";
+    case ParamDefinition::kParameterDefinitionDualCart16:
+      return "dual_cart16";
+    default:
+      return absl::StrCat("reserved(", static_cast<int>(t), ")");
+  }
+}
+
+std::string FlacBlockTypeToString(FlacMetaBlockHeader::FlacBlockType t) {
+  switch (t) {
+    case FlacMetaBlockHeader::kFlacStreamInfo:
+      return "StreamInfo";
+    case FlacMetaBlockHeader::kFlacPadding:
+      return "Padding";
+    case FlacMetaBlockHeader::kFlacApplication:
+      return "Application";
+    case FlacMetaBlockHeader::kFlacSeektable:
+      return "Seektable";
+    case FlacMetaBlockHeader::kFlacVorbisComment:
+      return "VorbisComment";
+    case FlacMetaBlockHeader::kFlacCuesheet:
+      return "Cuesheet";
+    case FlacMetaBlockHeader::kFlacPicture:
+      return "Picture";
+    case FlacMetaBlockHeader::kFlacInvalid:
+      return "Invalid";
+    default:
+      return absl::StrCat("reserved(", static_cast<int>(t), ")");
+  }
+}
+
+// Q7.8 fixed-point to float.
+float Q7_8ToFloat(int16_t v) { return static_cast<float>(v) / 256.0f; }
+
+// ---------- Codec config builders ----------
+
+OpusDecoderConfigReport BuildOpusReport(const OpusDecoderConfig& c) {
+  return {
+      .version = c.version_,
+      .output_channel_count = c.output_channel_count_,
+      .pre_skip = c.pre_skip_,
+      .input_sample_rate = c.input_sample_rate_,
+      .output_gain_q7_8 = c.output_gain_,
+      .output_gain = Q7_8ToFloat(c.output_gain_),
+      .mapping_family = c.mapping_family_,
+  };
+}
+
+LpcmDecoderConfigReport BuildLpcmReport(const LpcmDecoderConfig& c) {
+  return {
+      .sample_format = LpcmSampleFormatToString(c.sample_format_flags_bitmask_),
+      .sample_format_raw = static_cast<uint8_t>(c.sample_format_flags_bitmask_),
+      .sample_size = c.sample_size_,
+      .sample_rate = c.sample_rate_,
+  };
+}
+
+AacDecoderConfigReport BuildAacReport(const AacDecoderConfig& c) {
+  const auto& asc = c.decoder_specific_info_.audio_specific_config;
+  return {
+      .object_type_indication = c.object_type_indication_,
+      .stream_type = c.stream_type_,
+      .upstream = c.upstream_,
+      .reserved = c.reserved_,
+      .buffer_size_db = c.buffer_size_db_,
+      .max_bitrate = c.max_bitrate_,
+      .average_bit_rate = c.average_bit_rate_,
+      .audio_object_type = asc.audio_object_type_,
+      .sample_frequency_index =
+          AacSampleFrequencyIndexToString(asc.sample_frequency_index_),
+      .sample_frequency_index_raw =
+          static_cast<uint8_t>(asc.sample_frequency_index_),
+      .channel_configuration = asc.channel_configuration_,
+  };
+}
+
+FlacDecoderConfigReport BuildFlacReport(const FlacDecoderConfig& c) {
+  FlacDecoderConfigReport r;
+  r.metadata_blocks.reserve(c.metadata_blocks_.size());
+  for (const auto& block : c.metadata_blocks_) {
+    FlacMetaBlockReport mr;
+    mr.block_type = FlacBlockTypeToString(block.header.block_type);
+    mr.block_type_raw = static_cast<uint8_t>(block.header.block_type);
+    if (const auto* info =
+            std::get_if<FlacMetaBlockStreamInfo>(&block.payload)) {
+      mr.is_stream_info = true;
+      mr.minimum_block_size = info->minimum_block_size;
+      mr.maximum_block_size = info->maximum_block_size;
+      mr.minimum_frame_size = info->minimum_frame_size;
+      mr.maximum_frame_size = info->maximum_frame_size;
+      mr.sample_rate = info->sample_rate;
+      mr.number_of_channels = info->number_of_channels;
+      mr.bits_per_sample = info->bits_per_sample;
+      mr.total_samples_in_stream = info->total_samples_in_stream;
+    }
+    r.metadata_blocks.push_back(std::move(mr));
+  }
+  return r;
+}
+
+CodecConfigReport BuildCodecConfigReport(uint32_t id,
+                                         const CodecConfigObu& obu) {
+  const CodecConfig& cc = obu.GetCodecConfig();
+  CodecConfigReport r;
+  r.id = id;
+  r.codec_id = CodecIdToString(cc.codec_id);
+  r.codec_id_raw = static_cast<uint32_t>(cc.codec_id);
+  r.num_samples_per_frame = obu.GetNumSamplesPerFrame();
+  r.audio_roll_distance = cc.audio_roll_distance;
+  r.output_sample_rate = obu.GetOutputSampleRate();
+  r.input_sample_rate = obu.GetInputSampleRate();
+  r.bit_depth = static_cast<int>(obu.GetBitDepthToMeasureLoudness());
+
+  if (const auto* opus = std::get_if<OpusDecoderConfig>(&cc.decoder_config)) {
+    r.opus = BuildOpusReport(*opus);
+  } else if (const auto* lpcm =
+                 std::get_if<LpcmDecoderConfig>(&cc.decoder_config)) {
+    r.lpcm = BuildLpcmReport(*lpcm);
+  } else if (const auto* aac =
+                 std::get_if<AacDecoderConfig>(&cc.decoder_config)) {
+    r.aac = BuildAacReport(*aac);
+  } else if (const auto* flac =
+                 std::get_if<FlacDecoderConfig>(&cc.decoder_config)) {
+    r.flac = BuildFlacReport(*flac);
+  }
+  return r;
+}
+
+// ---------- Audio element builders ----------
+
+ChannelAudioLayerReport BuildLayerReport(const ChannelAudioLayerConfig& layer) {
+  ChannelAudioLayerReport r;
+  r.loudspeaker_layout = LoudspeakerLayoutToString(layer.loudspeaker_layout);
+  r.loudspeaker_layout_raw = static_cast<uint8_t>(layer.loudspeaker_layout);
+  if (layer.expanded_loudspeaker_layout.has_value()) {
+    r.expanded_loudspeaker_layout =
+        ExpandedLayoutToString(*layer.expanded_loudspeaker_layout);
+    r.expanded_loudspeaker_layout_raw =
+        static_cast<uint8_t>(*layer.expanded_loudspeaker_layout);
+  }
+  r.output_gain_is_present_flag = layer.output_gain_is_present_flag;
+  r.recon_gain_is_present_flag = layer.recon_gain_is_present_flag;
+  r.substream_count = layer.substream_count;
+  r.coupled_substream_count = layer.coupled_substream_count;
+  r.output_gain_flag = layer.output_gain_flag;
+  r.output_gain_q7_8 = layer.output_gain;
+  r.output_gain = Q7_8ToFloat(layer.output_gain);
+  return r;
+}
+
+AmbisonicsReport BuildAmbisonicsReport(const AmbisonicsConfig& ambi) {
+  AmbisonicsReport r;
+  const auto mode = ambi.GetAmbisonicsMode();
+  switch (mode) {
+    case AmbisonicsConfig::kAmbisonicsModeMono:
+      r.mode = "mono";
+      break;
+    case AmbisonicsConfig::kAmbisonicsModeProjection:
+      r.mode = "projection";
+      break;
+    default:
+      r.mode = absl::StrCat("reserved(", static_cast<int>(mode), ")");
+  }
+  r.mode_raw = static_cast<uint8_t>(mode);
+  int output_channels = 0;
+  if (const auto* mono =
+          std::get_if<AmbisonicsMonoConfig>(&ambi.ambisonics_config)) {
+    AmbisonicsMonoReport m;
+    m.output_channel_count = mono->GetOutputChannelCount();
+    m.substream_count = mono->GetSubstreamCount();
+    const auto channel_mapping = mono->GetChannelMappingView();
+    m.channel_mapping.assign(channel_mapping.begin(), channel_mapping.end());
+    output_channels = m.output_channel_count;
+    r.mono = std::move(m);
+  } else if (const auto* proj = std::get_if<AmbisonicsProjectionConfig>(
+                 &ambi.ambisonics_config)) {
+    AmbisonicsProjectionReport p;
+    p.output_channel_count = proj->GetOutputChannelCount();
+    p.substream_count = proj->GetSubstreamCount();
+    p.coupled_substream_count = proj->GetCoupledSubstreamCount();
+    const auto demixing_matrix = proj->GetDemixingMatrixView();
+    p.demixing_matrix.assign(demixing_matrix.begin(), demixing_matrix.end());
+    output_channels = p.output_channel_count;
+    r.projection = std::move(p);
+  }
+  if (output_channels > 0) {
+    int order = 0;
+    while ((order + 1) * (order + 1) < output_channels) ++order;
+    if ((order + 1) * (order + 1) == output_channels) {
+      r.order = order;
+    }
+  }
+  return r;
+}
+
+AudioElementParamReport BuildParamReport(const AudioElementParam& p) {
+  AudioElementParamReport r;
+  r.param_type = ParamDefinitionTypeToString(p.GetType());
+  r.param_type_raw = static_cast<uint32_t>(p.GetType());
+  std::visit(
+      [&](const auto& def) {
+        r.parameter_id = def.GetParameterId();
+        r.parameter_rate = def.GetParameterRate();
+        r.param_definition_mode =
+            static_cast<uint8_t>(def.GetParamDefinitionMode());
+        r.duration = def.GetDuration();
+        r.constant_subblock_duration = def.GetConstantSubblockDuration();
+      },
+      p.param_definition);
+  return r;
+}
+
+AudioElementReport BuildAudioElementReport(const AudioElementObu& obu) {
+  AudioElementReport r;
+  r.id = obu.GetAudioElementId();
+  r.type = AudioElementTypeToString(obu.GetAudioElementType());
+  r.type_raw = static_cast<uint8_t>(obu.GetAudioElementType());
+  r.codec_config_id = obu.GetCodecConfigId();
+  r.num_substreams = obu.GetNumSubstreams();
+  r.reserved = 0;  // AudioElementObu keeps `reserved_` private.
+
+  r.substream_ids.reserve(obu.audio_substream_ids_.size());
+  for (auto id : obu.audio_substream_ids_) {
+    r.substream_ids.push_back(static_cast<uint32_t>(id));
+  }
+
+  r.params.reserve(obu.audio_element_params_.size());
+  for (const auto& p : obu.audio_element_params_) {
+    r.params.push_back(BuildParamReport(p));
+  }
+
+  if (obu.GetAudioElementType() == AudioElementObu::kAudioElementChannelBased) {
+    if (const auto* scalable =
+            std::get_if<ScalableChannelLayoutConfig>(&obu.config_)) {
+      r.scalable_layers.reserve(scalable->channel_audio_layer_configs.size());
+      // The top-most layer's channel count is the sum across layers: each
+      // coupled substream carries two channels, each non-coupled one.
+      uint32_t num_channels = 0;
+      for (const auto& layer : scalable->channel_audio_layer_configs) {
+        r.scalable_layers.push_back(BuildLayerReport(layer));
+        num_channels += 2u * layer.coupled_substream_count +
+                        (layer.substream_count - layer.coupled_substream_count);
+      }
+      if (!scalable->channel_audio_layer_configs.empty()) {
+        const auto& top = scalable->channel_audio_layer_configs.back();
+        r.channel_layout = LoudspeakerLayoutToString(top.loudspeaker_layout);
+        r.channel_layout_raw = static_cast<uint8_t>(top.loudspeaker_layout);
+        if (top.expanded_loudspeaker_layout.has_value()) {
+          r.expanded_channel_layout_raw =
+              static_cast<uint8_t>(*top.expanded_loudspeaker_layout);
+        }
+        r.num_channels = num_channels;
+      }
+    }
+  } else if (obu.GetAudioElementType() ==
+             AudioElementObu::kAudioElementSceneBased) {
+    if (const auto* ambi = std::get_if<AmbisonicsConfig>(&obu.config_)) {
+      auto report = BuildAmbisonicsReport(*ambi);
+      if (report.mono.has_value()) {
+        r.ambisonics_channels = report.mono->output_channel_count;
+      } else if (report.projection.has_value()) {
+        r.ambisonics_channels = report.projection->output_channel_count;
+      }
+      if (r.ambisonics_channels.has_value()) {
+        r.num_channels = static_cast<uint32_t>(*r.ambisonics_channels);
+      }
+      r.ambisonics_order = report.order;
+      r.ambisonics = std::move(report);
+    }
+  }
+
+  return r;
+}
+
+// ---------- Mix presentation builders ----------
+
+ParamDefinitionReport BuildParamDefReport(const ParamDefinition& d) {
+  return {
+      .parameter_id = d.GetParameterId(),
+      .parameter_rate = d.GetParameterRate(),
+      .param_definition_mode = static_cast<uint8_t>(d.GetParamDefinitionMode()),
+      .duration = d.GetDuration(),
+      .constant_subblock_duration = d.GetConstantSubblockDuration(),
+  };
+}
+
+MixGainParamDefinitionReport BuildMixGainReport(
+    const MixGainParamDefinition& d) {
+  MixGainParamDefinitionReport r;
+  r.param_definition = BuildParamDefReport(d);
+  r.default_mix_gain_q7_8 = d.default_mix_gain_.GetQ7_8();
+  r.default_mix_gain = d.default_mix_gain_.GetFloatingPoint();
+  return r;
+}
+
+RenderingConfigReport BuildRenderingConfigReport(const RenderingConfig& rc) {
+  return {
+      .headphones_rendering_mode =
+          HeadphonesRenderingModeToString(rc.headphones_rendering_mode),
+      .headphones_rendering_mode_raw =
+          static_cast<uint8_t>(rc.headphones_rendering_mode),
+      .binaural_filter_profile =
+          BinauralFilterProfileToString(rc.binaural_filter_profile),
+      .binaural_filter_profile_raw =
+          static_cast<uint8_t>(rc.binaural_filter_profile),
+  };
+}
+
+SubMixAudioElementReport BuildSubMixAudioElementReport(
+    const SubMixAudioElement& a) {
+  SubMixAudioElementReport r;
+  r.audio_element_id = a.audio_element_id;
+  r.localized_element_annotations = a.localized_element_annotations;
+  r.rendering_config = BuildRenderingConfigReport(a.rendering_config);
+  r.element_mix_gain = BuildMixGainReport(a.element_mix_gain);
+  return r;
+}
+
+LayoutReport BuildLayoutReport(const Layout& layout) {
+  LayoutReport r;
+  r.layout_type = LayoutTypeToString(layout.layout_type);
+  r.layout_type_raw = static_cast<uint8_t>(layout.layout_type);
+  if (layout.layout_type == Layout::kLayoutTypeLoudspeakersSsConvention) {
+    if (const auto* ss = std::get_if<LoudspeakersSsConventionLayout>(
+            &layout.specific_layout)) {
+      r.sound_system = SoundSystemToString(ss->sound_system);
+      r.sound_system_raw = static_cast<uint8_t>(ss->sound_system);
+    }
+  }
+  return r;
+}
+
+LoudnessInfoReport BuildLoudnessReport(const LoudnessInfo& loud) {
+  LoudnessInfoReport r;
+  r.info_type = loud.info_type;
+  r.true_peak_present = (loud.info_type & LoudnessInfo::kTruePeak) != 0;
+  r.anchored_loudness_present =
+      (loud.info_type & LoudnessInfo::kAnchoredLoudness) != 0;
+  r.has_layout_extension =
+      (loud.info_type & LoudnessInfo::kAnyLayoutExtension) != 0;
+  r.integrated_loudness = Q7_8ToFloat(loud.integrated_loudness);
+  r.digital_peak = Q7_8ToFloat(loud.digital_peak);
+  if (r.true_peak_present) {
+    r.true_peak = Q7_8ToFloat(loud.true_peak);
+  }
+  if (r.anchored_loudness_present) {
+    r.anchored_loudness_elements.reserve(
+        loud.anchored_loudness.anchor_elements.size());
+    for (const auto& e : loud.anchored_loudness.anchor_elements) {
+      r.anchored_loudness_elements.push_back({
+          .anchor_element = AnchorElementToString(e.anchor_element),
+          .anchor_element_raw = static_cast<uint8_t>(e.anchor_element),
+          .anchored_loudness_q7_8 = e.anchored_loudness,
+          .anchored_loudness = Q7_8ToFloat(e.anchored_loudness),
+      });
+    }
+  }
+  return r;
+}
+
+MixPresentationLayoutReport BuildMpLayoutReport(
+    const MixPresentationLayout& mpl) {
+  return {
+      .loudness_layout = BuildLayoutReport(mpl.loudness_layout),
+      .loudness = BuildLoudnessReport(mpl.loudness),
+  };
+}
+
+SubMixReport BuildSubMixReport(const MixPresentationSubMix& sm) {
+  SubMixReport r;
+  r.audio_elements.reserve(sm.audio_elements.size());
+  for (const auto& a : sm.audio_elements) {
+    r.audio_elements.push_back(BuildSubMixAudioElementReport(a));
+  }
+  r.output_mix_gain = BuildMixGainReport(sm.output_mix_gain);
+  r.layouts.reserve(sm.layouts.size());
+  for (const auto& l : sm.layouts) {
+    r.layouts.push_back(BuildMpLayoutReport(l));
+  }
+  return r;
+}
+
+MixPresentationReport BuildMixPresentationReport(
+    const MixPresentationObu& obu) {
+  MixPresentationReport r;
+  r.id = obu.GetMixPresentationId();
+
+  const auto langs = obu.GetAnnotationsLanguage();
+  const auto labels = obu.GetLocalizedPresentationAnnotations();
+  if (langs.size() != labels.size()) {
+    ABSL_LOG(WARNING) << "MixPresentation " << r.id
+                      << ": annotation language/label size mismatch ("
+                      << langs.size() << " vs " << labels.size()
+                      << "); reporting only the overlapping prefix.";
+  }
+  r.count_label = static_cast<uint32_t>(std::min(langs.size(), labels.size()));
+  r.annotations.reserve(r.count_label);
+  for (size_t i = 0; i < r.count_label; ++i) {
+    r.annotations.emplace_back(langs[i], labels[i]);
+  }
+
+  r.num_sub_mixes = static_cast<uint32_t>(std::min<size_t>(
+      obu.sub_mixes_.size(), std::numeric_limits<uint32_t>::max()));
+  r.sub_mixes.reserve(obu.sub_mixes_.size());
+  for (const auto& sm : obu.sub_mixes_) {
+    r.sub_mixes.push_back(BuildSubMixReport(sm));
+  }
+
+  if (obu.mix_presentation_tags_.has_value()) {
+    r.tags.reserve(obu.mix_presentation_tags_->tags.size());
+    for (const auto& t : obu.mix_presentation_tags_->tags) {
+      r.tags.push_back({t.tag_name, t.tag_value});
+    }
+  }
+
+  // Backwards-compatible summary fields from first sub-mix / first layout.
+  if (!r.sub_mixes.empty()) {
+    const auto& first = r.sub_mixes.front();
+    r.layouts.reserve(first.layouts.size());
+    for (const auto& mpl : first.layouts) {
+      r.layouts.push_back(mpl.loudness_layout.sound_system.value_or(
+          mpl.loudness_layout.layout_type));
+    }
+    if (!first.layouts.empty()) {
+      const auto& loud = first.layouts.front().loudness;
+      r.integrated_loudness_lkfs = loud.integrated_loudness;
+      r.digital_peak_dbfs = loud.digital_peak;
+      r.true_peak_dbfs = loud.true_peak;
+    }
+  }
+  return r;
+}
+
+// ---------- Temporal unit scan helpers ----------
+
+std::string DMixPModeToString(DemixingInfoParameterData::DMixPMode m) {
+  switch (m) {
+    case DemixingInfoParameterData::kDMixPMode1:
+      return "mode1";
+    case DemixingInfoParameterData::kDMixPMode2:
+      return "mode2";
+    case DemixingInfoParameterData::kDMixPMode3:
+      return "mode3";
+    case DemixingInfoParameterData::kDMixPMode1_n:
+      return "mode1_n";
+    case DemixingInfoParameterData::kDMixPMode2_n:
+      return "mode2_n";
+    case DemixingInfoParameterData::kDMixPMode3_n:
+      return "mode3_n";
+    case DemixingInfoParameterData::kDMixPModeReserved1:
+      return "reserved_1";
+    case DemixingInfoParameterData::kDMixPModeReserved2:
+      return "reserved_2";
+  }
+  return absl::StrCat("reserved(", static_cast<int>(m), ")");
+}
+
+std::string AnimationTypeToString(MixGainParameterData::AnimationType t) {
+  switch (t) {
+    case MixGainParameterData::kAnimateStep:
+      return "step";
+    case MixGainParameterData::kAnimateLinear:
+      return "linear";
+    case MixGainParameterData::kAnimateBezier:
+      return "bezier";
+  }
+  return absl::StrCat("reserved(", static_cast<int>(t), ")");
+}
+
+MixGainAnimationReport BuildMixGainAnimationReport(
+    const MixGainParameterData& data) {
+  MixGainAnimationReport r;
+  r.animation_type = AnimationTypeToString(data.GetAnimationType());
+  r.animation_type_raw = static_cast<uint32_t>(data.GetAnimationType());
+  const auto set_start = [&r](int16_t v) {
+    r.start_point_value_q7_8 = v;
+    r.start_point_value = Q7_8ToFloat(v);
+  };
+  const auto set_end = [&r](int16_t v) {
+    r.end_point_value_q7_8 = v;
+    r.end_point_value = Q7_8ToFloat(v);
+  };
+  if (const auto* step = std::get_if<AnimationStepInt16>(&data.param_data)) {
+    set_start(step->start_point_value);
+  } else if (const auto* linear =
+                 std::get_if<AnimationLinearInt16>(&data.param_data)) {
+    set_start(linear->start_point_value);
+    set_end(linear->end_point_value);
+  } else if (const auto* bezier =
+                 std::get_if<AnimationBezierInt16>(&data.param_data)) {
+    set_start(bezier->start_point_value);
+    set_end(bezier->end_point_value);
+    r.control_point_value_q7_8 = bezier->control_point_value;
+    r.control_point_value = Q7_8ToFloat(bezier->control_point_value);
+    r.control_point_relative_time = bezier->control_point_relative_time;
+  }
+  return r;
+}
+
+ReconGainInfoReport BuildReconGainReport(const ReconGainInfoParameterData& d) {
+  ReconGainInfoReport r;
+  // `layer_index` is a uint8_t; beyond 255 layers we would silently wrap.
+  // The IAMF spec caps scalable channel layers well below this, so clamp
+  // defensively rather than risk reporting a bogus index.
+  const size_t n = std::min<size_t>(d.recon_gain_elements.size(), 256);
+  r.layers.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    const auto& element = d.recon_gain_elements[i];
+    if (!element.has_value()) continue;
+    ReconGainForLayerReport layer;
+    layer.layer_index = static_cast<uint8_t>(i);
+    layer.recon_gain_flag = element->recon_gain_flag;
+    // Emit only the bytes for channels whose flag bit is set.
+    for (int bit = 0; bit < 12; ++bit) {
+      if ((element->recon_gain_flag >> bit) & 1u) {
+        layer.recon_gain.push_back(element->recon_gain[bit]);
+      }
+    }
+    r.layers.push_back(std::move(layer));
+  }
+  return r;
+}
+
+ParameterBlockReport BuildParameterBlockReport(const ParameterBlockObu& obu,
+                                               absl::string_view param_type,
+                                               uint32_t param_type_raw,
+                                               uint64_t start_timestamp,
+                                               uint64_t end_timestamp) {
+  ParameterBlockReport r;
+  r.parameter_id = obu.parameter_id_;
+  r.param_type = std::string(param_type);
+  r.param_type_raw = param_type_raw;
+  r.start_timestamp = start_timestamp;
+  r.end_timestamp = end_timestamp;
+  r.duration = obu.GetDuration();
+  r.constant_subblock_duration = obu.GetConstantSubblockDuration();
+  r.subblocks.reserve(obu.subblocks_.size());
+  for (size_t i = 0; i < obu.subblocks_.size(); ++i) {
+    ParameterSubblockReport sub;
+    const auto duration_or = obu.GetSubblockDuration(static_cast<int>(i));
+    if (duration_or.ok()) sub.subblock_duration = *duration_or;
+    const auto& subblock = obu.subblocks_[i];
+    if (subblock == nullptr) {
+      r.subblocks.push_back(std::move(sub));
+      continue;
+    }
+    const ParameterData* data = subblock.get();
+    if (const auto* mg = dynamic_cast<const MixGainParameterData*>(data)) {
+      sub.mix_gain = BuildMixGainAnimationReport(*mg);
+    } else if (const auto* dx =
+                   dynamic_cast<const DemixingInfoParameterData*>(data)) {
+      DemixingInfoReport dr;
+      dr.dmixp_mode = DMixPModeToString(dx->dmixp_mode);
+      dr.dmixp_mode_raw = static_cast<uint8_t>(dx->dmixp_mode);
+      dr.reserved = dx->reserved;
+      sub.demixing = std::move(dr);
+    } else if (const auto* rg =
+                   dynamic_cast<const ReconGainInfoParameterData*>(data)) {
+      sub.recon_gain = BuildReconGainReport(*rg);
+    }
+    r.subblocks.push_back(std::move(sub));
+  }
+  return r;
+}
+
+// Walks temporal units from the buffer's current position and fills `out`.
+// The `read_bit_buffer` should be positioned immediately after the last
+// descriptor OBU. Does not return an error; temporal-unit parsing is best-
+// effort, and malformed OBUs are skipped in the spirit of the spec. Sets
+// `out.stopped_reason` to indicate why the walk ended.
+void ScanTemporalUnits(
+    const DescriptorObus& descriptors,
+    const absl::flat_hash_map<DecodedUleb128, ParamDefinitionVariant>&
+        param_definition_variants,
+    const ProbeOptions& options, ReadBitBuffer& read_bit_buffer,
+    TemporalUnitScanReport& out) {
+  const bool collect_details = options.scan_mode == ScanMode::kScanFull;
+  // Per-substream frame size + codec-config id, so we can tally samples and
+  // label substreams in the report.
+  absl::flat_hash_map<DecodedUleb128, uint32_t> substream_to_frame_size;
+  absl::flat_hash_map<DecodedUleb128, uint32_t> substream_to_codec_config_id;
+  for (const auto& [audio_element_id, element_with_data] :
+       descriptors.audio_elements) {
+    for (const auto substream_id : element_with_data.obu.audio_substream_ids_) {
+      if (element_with_data.codec_config != nullptr) {
+        substream_to_frame_size[substream_id] =
+            element_with_data.codec_config->GetNumSamplesPerFrame();
+        substream_to_codec_config_id[substream_id] =
+            element_with_data.obu.GetCodecConfigId();
+      }
+    }
+  }
+
+  // Parameter-id -> type, so we can label blocks in the report.
+  absl::flat_hash_map<DecodedUleb128, ParamDefinition::ParameterDefinitionType>
+      parameter_id_to_type;
+  for (const auto& [parameter_id, variant] : param_definition_variants) {
+    // Copy the structured binding into a plain local before capturing it in the
+    // lambda: capturing a structured binding directly is only well-formed in
+    // C++20 and is rejected by some toolchains (e.g. Apple Clang in
+    // Xcode 15.4).
+    const DecodedUleb128 id = parameter_id;
+    std::visit(
+        [&](const auto& def) { parameter_id_to_type[id] = def.GetType(); },
+        variant);
+  }
+
+  // Track per-substream totals + per-parameter timestamps.
+  absl::flat_hash_map<DecodedUleb128, AudioFrameSummaryReport> per_substream;
+  absl::flat_hash_map<DecodedUleb128, uint64_t> per_parameter_timestamp;
+
+  const int64_t scan_start_bits = read_bit_buffer.Tell();
+
+  // Per-TU index state. A TU begins at the byte offset of its first OBU and
+  // ends when either (a) a temporal delimiter OBU marks a boundary, or (b) an
+  // audio frame arrives for a substream that has already appeared in the
+  // current TU (each substream emits exactly one frame per TU in IAMF). The
+  // cumulative sum of finalised `num_samples` feeds each successive entry's
+  // `start_timestamp`.
+  struct PendingTu {
+    int64_t start_byte_offset = -1;
+    uint64_t num_samples = 0;
+    uint32_t trim_at_start = 0;
+    uint32_t trim_at_end = 0;
+    absl::flat_hash_set<DecodedUleb128> substreams_seen;
+  };
+  PendingTu pending_tu;
+  uint64_t cumulative_timestamp = 0;
+  uint32_t finalized_tu_count = 0;
+  auto note_tu_start = [&](size_t byte_offset) {
+    if (pending_tu.start_byte_offset < 0) {
+      pending_tu.start_byte_offset = static_cast<int64_t>(byte_offset);
+    }
+  };
+  auto finalize_tu = [&]() {
+    if (pending_tu.start_byte_offset < 0) return;
+    // Skip pending state with no audio frames; that's parameter-block-only
+    // scaffolding (seen only in test-shaped inputs), not a real TU. Keeps
+    // `temporal_units.size()` consistent with `temporal_unit_count`.
+    if (pending_tu.substreams_seen.empty()) {
+      pending_tu = PendingTu{};
+      return;
+    }
+    ++finalized_tu_count;
+    if (collect_details) {
+      TemporalUnitEntry entry;
+      entry.start_timestamp = cumulative_timestamp;
+      entry.num_samples = pending_tu.num_samples;
+      entry.byte_offset_from_scan_start =
+          static_cast<size_t>(pending_tu.start_byte_offset);
+      entry.samples_to_trim_at_start = pending_tu.trim_at_start;
+      entry.samples_to_trim_at_end = pending_tu.trim_at_end;
+      out.temporal_units.push_back(entry);
+    }
+    cumulative_timestamp += pending_tu.num_samples;
+    pending_tu = PendingTu{};
+  };
+
+  // Each iteration must consume bytes, so the loop is naturally bounded by
+  // the input size; `max_scan_obu_iterations` additionally caps latency on
+  // adversarial inputs of tiny reserved OBUs.
+  uint64_t iterations = 0;
+  for (;;) {
+    if (++iterations > options.max_scan_obu_iterations) {
+      out.stopped_reason = "scan_budget_exceeded";
+      break;
+    }
+    if (options.should_continue != nullptr &&
+        !options.should_continue(ScanProgress{
+            .bytes_consumed = static_cast<size_t>(
+                (read_bit_buffer.Tell() - scan_start_bits) / 8),
+            .temporal_unit_count = finalized_tu_count,
+        })) {
+      out.stopped_reason = "cancelled";
+      break;
+    }
+    const int64_t position_before_header = read_bit_buffer.Tell();
+    const int64_t bytes_available_before_header =
+        read_bit_buffer.NumBytesAvailable();
+    auto header_metadata =
+        ObuHeader::PeekObuTypeAndTotalObuSize(read_bit_buffer);
+    if (!header_metadata.ok()) {
+      if (header_metadata.status().code() ==
+          absl::StatusCode::kResourceExhausted) {
+        out.stopped_reason =
+            bytes_available_before_header == 0 ? "eof" : "truncated";
+      } else {
+        out.stopped_reason = "malformed";
+      }
+      break;
+    }
+    if (read_bit_buffer.NumBytesAvailable() < header_metadata->total_obu_size) {
+      out.stopped_reason = "truncated";
+      break;
+    }
+
+    ObuHeader header;
+    int64_t payload_size = 0;
+    const auto header_status =
+        header.ReadAndValidate(read_bit_buffer, payload_size);
+    if (!header_status.ok()) {
+      // Malformed header; skip this OBU and continue.
+      if (!read_bit_buffer.Seek(position_before_header).ok() ||
+          !read_bit_buffer.IgnoreBytes(header_metadata->total_obu_size).ok()) {
+        out.stopped_reason = "malformed";
+        break;
+      }
+      continue;
+    }
+
+    bool stop_walk = false;
+    bool handled = false;
+    switch (header.obu_type) {
+      case kObuIaAudioFrame:
+      case kObuIaAudioFrameId0:
+      case kObuIaAudioFrameId1:
+      case kObuIaAudioFrameId2:
+      case kObuIaAudioFrameId3:
+      case kObuIaAudioFrameId4:
+      case kObuIaAudioFrameId5:
+      case kObuIaAudioFrameId6:
+      case kObuIaAudioFrameId7:
+      case kObuIaAudioFrameId8:
+      case kObuIaAudioFrameId9:
+      case kObuIaAudioFrameId10:
+      case kObuIaAudioFrameId11:
+      case kObuIaAudioFrameId12:
+      case kObuIaAudioFrameId13:
+      case kObuIaAudioFrameId14:
+      case kObuIaAudioFrameId15:
+      case kObuIaAudioFrameId16:
+      case kObuIaAudioFrameId17: {
+        const size_t frame_start_offset =
+            static_cast<size_t>((position_before_header - scan_start_bits) / 8);
+        // Duration accounting needs only the substream id (implicit in the
+        // OBU type, or one leading ULEB128 for `kObuIaAudioFrame`), so the
+        // codec payload is skipped without parsing or copying it.
+        DecodedUleb128 substream_id = 0;
+        int64_t bytes_to_skip = payload_size;
+        if (header.obu_type == kObuIaAudioFrame) {
+          int8_t encoded_uleb128_size = 0;
+          if (!read_bit_buffer.ReadULeb128(substream_id, encoded_uleb128_size)
+                   .ok() ||
+              payload_size < encoded_uleb128_size) {
+            ++out.audio_frame_parse_errors;
+            break;
+          }
+          bytes_to_skip -= encoded_uleb128_size;
+        } else {
+          substream_id = header.obu_type - kObuIaAudioFrameId0;
+        }
+        if (!read_bit_buffer.IgnoreBytes(bytes_to_skip).ok()) {
+          ++out.audio_frame_parse_errors;
+          break;
+        }
+        // TU boundary: repeated substream within the pending TU signals that
+        // a new TU has begun. Finalise the pending TU before attributing this
+        // frame to the new one.
+        if (pending_tu.substreams_seen.contains(substream_id)) {
+          finalize_tu();
+        }
+        note_tu_start(frame_start_offset);
+        // First audio frame in a new TU supplies the canonical trim values.
+        // Subsequent frames in the same TU carry identical values in
+        // conformant streams; we trust the first-frame reading.
+        if (pending_tu.substreams_seen.empty()) {
+          pending_tu.trim_at_start =
+              static_cast<uint32_t>(header.num_samples_to_trim_at_start);
+          pending_tu.trim_at_end =
+              static_cast<uint32_t>(header.num_samples_to_trim_at_end);
+        }
+        pending_tu.substreams_seen.insert(substream_id);
+        uint32_t frame_size = 0;
+        if (auto it = substream_to_frame_size.find(substream_id);
+            it != substream_to_frame_size.end()) {
+          frame_size = it->second;
+        }
+        pending_tu.num_samples =
+            std::max(pending_tu.num_samples, uint64_t{frame_size});
+        auto& summary = per_substream[substream_id];
+        summary.substream_id = substream_id;
+        if (auto it = substream_to_codec_config_id.find(substream_id);
+            it != substream_to_codec_config_id.end()) {
+          summary.codec_config_id = it->second;
+        }
+        ++summary.frame_count;
+        summary.total_samples += frame_size;
+        ++out.audio_frame_count;
+        handled = true;
+        break;
+      }
+      case kObuIaParameterBlock: {
+        const size_t block_start_offset =
+            static_cast<size_t>((position_before_header - scan_start_bits) / 8);
+        auto peek_id = ParameterBlockObu::PeekParameterId(read_bit_buffer);
+        if (!peek_id.ok()) {
+          ++out.parameter_block_parse_errors;
+          break;
+        }
+        note_tu_start(block_start_offset);
+        auto def_it = param_definition_variants.find(*peek_id);
+        if (def_it == param_definition_variants.end()) {
+          // Descriptors didn't declare this parameter id; we can't parse the
+          // body, so count it as a skipped block.
+          ++out.parameter_block_parse_errors;
+          break;
+        }
+        const ParamDefinition* param_definition = std::visit(
+            [](const auto& def) -> const ParamDefinition* { return &def; },
+            def_it->second);
+        if (param_definition == nullptr) {
+          ++out.parameter_block_parse_errors;
+          break;
+        }
+        if (!collect_details) {
+          // Block contents are only surfaced in the detailed report; skip
+          // the body unparsed (the peek above left the buffer untouched).
+          if (!read_bit_buffer.IgnoreBytes(payload_size).ok()) {
+            ++out.parameter_block_parse_errors;
+            break;
+          }
+          ++out.parameter_block_count;
+          handled = true;
+          break;
+        }
+        auto block_or = ParameterBlockObu::CreateFromBuffer(
+            header, payload_size, *param_definition, read_bit_buffer);
+        if (!block_or.ok()) {
+          ++out.parameter_block_parse_errors;
+          break;
+        }
+        auto type_it = parameter_id_to_type.find(*peek_id);
+        const bool type_known = type_it != parameter_id_to_type.end();
+        const std::string param_type =
+            type_known ? ParamDefinitionTypeToString(type_it->second)
+                       : "unknown";
+        const uint32_t param_type_raw =
+            type_known ? static_cast<uint32_t>(type_it->second) : 0;
+        const uint64_t start_ts = per_parameter_timestamp[*peek_id];
+        const uint64_t end_ts = start_ts + (*block_or)->GetDuration();
+        per_parameter_timestamp[*peek_id] = end_ts;
+        out.parameter_blocks.push_back(BuildParameterBlockReport(
+            **block_or, param_type, param_type_raw, start_ts, end_ts));
+        ++out.parameter_block_count;
+        handled = true;
+        break;
+      }
+      case kObuIaTemporalDelimiter: {
+        const size_t td_start_offset =
+            static_cast<size_t>((position_before_header - scan_start_bits) / 8);
+        // A temporal delimiter marks the start of a new TU (IAMF 6.1.7):
+        // finalise whatever pending frames preceded it, then begin the next
+        // TU at the TD's byte offset.
+        finalize_tu();
+        note_tu_start(td_start_offset);
+        ++out.temporal_delimiter_count;
+        // Header parsed and the OBU size fit in the buffer, so a skip failure
+        // here would indicate a bit-buffer inconsistency rather than missing
+        // bytes.
+        if (!read_bit_buffer.IgnoreBytes(payload_size).ok()) {
+          out.stopped_reason = "malformed";
+          stop_walk = true;
+        }
+        handled = true;
+        break;
+      }
+      case kObuIaSequenceHeader:
+        if (!header.obu_redundant_copy) {
+          // Rewind so the caller sees the start of the next IA sequence.
+          (void)read_bit_buffer.Seek(position_before_header);
+          out.stopped_reason = "next_ia_sequence";
+          stop_walk = true;
+          handled = true;
+          break;
+        }
+        [[fallthrough]];
+      case kObuIaCodecConfig:
+      case kObuIaAudioElement:
+      case kObuIaMixPresentation:
+        // Skip redundant copies.
+        (void)read_bit_buffer.IgnoreBytes(payload_size);
+        handled = true;
+        break;
+      default:
+        // Reserved OBU; skip.
+        (void)read_bit_buffer.IgnoreBytes(payload_size);
+        handled = true;
+        break;
+    }
+
+    if (!handled) {
+      // A parse failed inside one of the cases; fall back to the skip pattern.
+      // The header peeked cleanly and total_obu_size bytes were confirmed
+      // available above, so a seek/skip failure here is a buffer-level
+      // inconsistency rather than truncation.
+      if (!read_bit_buffer.Seek(position_before_header).ok() ||
+          !read_bit_buffer.IgnoreBytes(header_metadata->total_obu_size).ok()) {
+        out.stopped_reason = "malformed";
+        break;
+      }
+    }
+
+    if (stop_walk) break;
+
+    // Defensive: every iteration must consume bytes. Catches buffer-state
+    // bugs that would otherwise loop forever.
+    if (read_bit_buffer.Tell() <= position_before_header) {
+      out.stopped_reason = "malformed";
+      break;
+    }
+  }
+
+  // Flush the last in-flight TU, if any. The scan loop only finalises on
+  // boundaries it observes in-stream; the final TU has no successor to trigger
+  // that path.
+  finalize_tu();
+
+  // In IAMF each temporal unit emits exactly one audio frame per substream, so
+  // the max frame count across substreams equals the TU count.
+  uint32_t max_frames = 0;
+  for (const auto& [_, summary] : per_substream) {
+    max_frames = std::max(max_frames, summary.frame_count);
+  }
+  out.temporal_unit_count = std::max(max_frames, out.temporal_delimiter_count);
+
+  // Flatten per_substream map, sorted by substream id for stable output.
+  std::vector<DecodedUleb128> substream_ids;
+  substream_ids.reserve(per_substream.size());
+  for (const auto& [id, _] : per_substream) substream_ids.push_back(id);
+  std::sort(substream_ids.begin(), substream_ids.end());
+  out.audio_frames_by_substream.reserve(substream_ids.size());
+  uint64_t max_samples = 0;
+  for (auto id : substream_ids) {
+    out.audio_frames_by_substream.push_back(per_substream[id]);
+    max_samples = std::max(max_samples, per_substream[id].total_samples);
+  }
+  if (max_samples > 0) {
+    out.total_samples = max_samples;
+    // Pick an output sample rate from the first codec config.
+    if (!descriptors.codec_config_obus.empty()) {
+      const auto& [unused_id, codec_cfg] =
+          *descriptors.codec_config_obus.begin();
+      const uint32_t rate = codec_cfg.GetOutputSampleRate();
+      if (rate > 0) {
+        out.output_sample_rate = rate;
+        out.duration_seconds =
+            static_cast<double>(max_samples) / static_cast<double>(rate);
+      }
+    }
+  }
+
+  out.bytes_consumed =
+      static_cast<size_t>((read_bit_buffer.Tell() - scan_start_bits) / 8);
+  if (out.stopped_reason.empty()) out.stopped_reason = "eof";
+}
+
+// Shared body of `Probe` and `ProbeFile`: parses descriptors (and optionally
+// scans temporal units) from an already-positioned buffer.
+absl::StatusOr<ProbeReport> ProbeFromBuffer(ReadBitBuffer& read_bit_buffer,
+                                            ProbeOptions options) {
+  bool insufficient_data = false;
+  auto descriptors_or = DescriptorObuParser::ProcessDescriptorObus(
+      /*is_exhaustive_and_exact=*/false, read_bit_buffer, insufficient_data);
+  if (!descriptors_or.ok()) {
+    if (insufficient_data) {
+      // Distinct code so incremental callers can read more bytes and retry
+      // without string-matching the message.
+      return absl::ResourceExhaustedError(
+          absl::StrCat("Insufficient data to parse descriptor OBUs: ",
+                       descriptors_or.status().message()));
+    }
+    return absl::InvalidArgumentError(
+        absl::StrCat("Failed to parse descriptor OBUs: ",
+                     descriptors_or.status().message()));
+  }
+  const DescriptorObus& descriptors = *descriptors_or;
+
+  ProbeReport report;
+  report.descriptor_bytes_consumed =
+      static_cast<size_t>(read_bit_buffer.Tell() / 8);
+
+  report.primary_profile =
+      ProfileToString(descriptors.ia_sequence_header.GetPrimaryProfile());
+  report.primary_profile_raw =
+      static_cast<uint8_t>(descriptors.ia_sequence_header.GetPrimaryProfile());
+  report.additional_profile =
+      ProfileToString(descriptors.ia_sequence_header.GetAdditionalProfile());
+  report.additional_profile_raw = static_cast<uint8_t>(
+      descriptors.ia_sequence_header.GetAdditionalProfile());
+
+  report.codec_configs.reserve(descriptors.codec_config_obus.size());
+  for (const auto& [id, obu] : descriptors.codec_config_obus) {
+    report.codec_configs.push_back(BuildCodecConfigReport(id, obu));
+  }
+
+  report.audio_elements.reserve(descriptors.audio_elements.size());
+  for (const auto& [id, element_with_data] : descriptors.audio_elements) {
+    report.audio_elements.push_back(
+        BuildAudioElementReport(element_with_data.obu));
+  }
+
+  report.mix_presentations.reserve(descriptors.mix_presentation_obus.size());
+  for (const auto& mp : descriptors.mix_presentation_obus) {
+    report.mix_presentations.push_back(BuildMixPresentationReport(mp));
+  }
+
+  // FLAC STREAMINFO can carry the stream's total sample count, yielding a
+  // duration estimate without walking any temporal units.
+  for (const auto& cc : report.codec_configs) {
+    if (!cc.flac.has_value()) continue;
+    for (const auto& block : cc.flac->metadata_blocks) {
+      if (!block.is_stream_info || block.total_samples_in_stream == 0) {
+        continue;
+      }
+      report.descriptor_total_samples = block.total_samples_in_stream;
+      const uint32_t rate =
+          block.sample_rate > 0 ? block.sample_rate : cc.output_sample_rate;
+      if (rate > 0) {
+        report.descriptor_duration_seconds =
+            static_cast<double>(block.total_samples_in_stream) /
+            static_cast<double>(rate);
+      }
+      break;
+    }
+    if (report.descriptor_total_samples.has_value()) break;
+  }
+
+  if (options.scan_mode != ScanMode::kDescriptorsOnly) {
+    absl::flat_hash_map<DecodedUleb128, ParamDefinitionVariant>
+        param_definition_variants;
+    const auto collect_status = CollectAndValidateParamDefinitions(
+        descriptors.audio_elements, descriptors.mix_presentation_obus,
+        param_definition_variants);
+    if (!collect_status.ok()) {
+      ABSL_LOG(WARNING) << "Parameter definitions validation failed; "
+                           "continuing with best-effort scan: "
+                        << collect_status;
+    }
+    TemporalUnitScanReport scan;
+    ScanTemporalUnits(descriptors, param_definition_variants, options,
+                      read_bit_buffer, scan);
+    report.temporal_unit_scan = std::move(scan);
+  }
+
+  return report;
+}
+
+}  // namespace
+
+absl::StatusOr<ProbeReport> Probe(absl::Span<const uint8_t> data,
+                                  ProbeOptions options) {
+  auto read_bit_buffer = MemoryBasedReadBitBuffer::CreateFromSpan(data);
+  if (read_bit_buffer == nullptr) {
+    return absl::InternalError("Failed to create read bit buffer");
+  }
+  return ProbeFromBuffer(*read_bit_buffer, options);
+}
+
+absl::StatusOr<ProbeReport> ProbeFile(const std::string& path,
+                                      ProbeOptions options) {
+  // The window only bounds single-shot loads; multi-byte reads refill it on
+  // demand, so the size is a memory/I/O trade-off, not a limit on OBU or
+  // descriptor sizes.
+  constexpr int64_t kFileWindowBytes = 64 * 1024;
+  auto read_bit_buffer =
+      FileBasedReadBitBuffer::CreateFromFilePath(kFileWindowBytes, path);
+  if (read_bit_buffer == nullptr) {
+    return absl::NotFoundError(
+        absl::StrCat("Failed to open file for probing: ", path));
+  }
+  auto report = ProbeFromBuffer(*read_bit_buffer, options);
+  if (absl::IsResourceExhausted(report.status())) {
+    // The whole file is visible, so "more bytes needed" cannot be satisfied
+    // by retrying: surface it as invalid (truncated) input instead.
+    return absl::InvalidArgumentError(report.status().message());
+  }
+  return report;
+}
+
+}  // namespace iamf_tools

--- a/iamf/cli/probe.h
+++ b/iamf/cli/probe.h
@@ -1,0 +1,618 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#ifndef CLI_PROBE_H_
+#define CLI_PROBE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+
+namespace iamf_tools {
+
+// The `*Report` structs below mirror the wire-level fields of the
+// corresponding OBUs, lightly decoded for readability. Conventions shared by
+// all of them:
+//
+//   - Enum-like fields are reported as lower-case strings (e.g. "mix_gain",
+//     "channel_based"). Values the spec marks as reserved are reported as
+//     "reserved(N)" where N is the raw coded value. Each enum string is
+//     accompanied by a sibling `*_raw` field carrying the raw coded value,
+//     so programmatic consumers can branch on stable values instead of
+//     display labels.
+//   - Q7.8 fixed-point quantities are reported as both the raw coded
+//     `int16_t` (`*_q7_8`) and the decoded `float` (raw / 256.0).
+//   - Field names follow the IAMF specification
+//     (https://aomediacodec.github.io/iamf/) unless noted otherwise.
+
+// ---------- Codec Config ----------
+
+/*!\brief Opus decoder config fields of a Codec Config OBU.
+ *
+ * Mirrors the `OpusDecoderConfig` syntax element, which itself mirrors the
+ * Ogg Opus identification header.
+ */
+struct OpusDecoderConfigReport {
+  uint8_t version;
+  uint8_t output_channel_count;
+  uint16_t pre_skip;
+  uint32_t input_sample_rate;
+  int16_t output_gain_q7_8;  // Raw signed Q7.8 gain.
+  float output_gain;         // Decoded (raw / 256.0), in dB.
+  uint8_t mapping_family;
+};
+
+/*!\brief LPCM decoder config fields of a Codec Config OBU. */
+struct LpcmDecoderConfigReport {
+  std::string sample_format;  // "little_endian", "big_endian", "reserved(N)".
+  uint8_t sample_format_raw;
+  uint8_t sample_size;   // Bits per sample.
+  uint32_t sample_rate;  // Hz.
+};
+
+/*!\brief AAC-LC decoder config fields of a Codec Config OBU.
+ *
+ * Field names follow the embedded `DecoderConfigDescriptor` /
+ * `AudioSpecificConfig` (ISO 14496-1 / 14496-3) syntax.
+ */
+struct AacDecoderConfigReport {
+  uint8_t object_type_indication;
+  uint8_t stream_type;
+  bool upstream;
+  bool reserved;
+  uint32_t buffer_size_db;
+  uint32_t max_bitrate;
+  uint32_t average_bit_rate;
+  uint8_t audio_object_type;
+  std::string sample_frequency_index;  // e.g. "48000", "reserved(13)".
+  uint8_t sample_frequency_index_raw;
+  uint8_t channel_configuration;
+};
+
+/*!\brief One FLAC metadata block of a FLAC Codec Config OBU.
+ *
+ * The STREAMINFO fields below `is_stream_info` are only populated when
+ * `is_stream_info` is true; other block types report only `block_type`.
+ */
+struct FlacMetaBlockReport {
+  std::string block_type;  // e.g. "StreamInfo", "Padding", "reserved(7)".
+  uint8_t block_type_raw = 0;
+  bool is_stream_info = false;
+  uint16_t minimum_block_size = 0;
+  uint16_t maximum_block_size = 0;
+  uint32_t minimum_frame_size = 0;
+  uint32_t maximum_frame_size = 0;
+  uint32_t sample_rate = 0;
+  uint8_t number_of_channels = 0;
+  uint8_t bits_per_sample = 0;
+  uint64_t total_samples_in_stream = 0;
+};
+
+/*!\brief FLAC decoder config fields of a Codec Config OBU. */
+struct FlacDecoderConfigReport {
+  std::vector<FlacMetaBlockReport> metadata_blocks;
+};
+
+/*!\brief Summary of one Codec Config OBU. */
+struct CodecConfigReport {
+  uint32_t id;
+  std::string codec_id;   // "Opus", "FLAC", "LPCM", "AAC LC".
+  uint32_t codec_id_raw;  // The four-character code as a big-endian u32.
+  uint32_t num_samples_per_frame;
+  int16_t audio_roll_distance;
+  uint32_t output_sample_rate;
+  uint32_t input_sample_rate;
+  // Bit depth used to measure loudness; not necessarily the coded sample
+  // size (see `LpcmDecoderConfigReport::sample_size`).
+  int bit_depth;
+
+  // Exactly one of these is populated, matching `codec_id`.
+  std::optional<OpusDecoderConfigReport> opus;
+  std::optional<LpcmDecoderConfigReport> lpcm;
+  std::optional<AacDecoderConfigReport> aac;
+  std::optional<FlacDecoderConfigReport> flac;
+};
+
+// ---------- Audio Element ----------
+
+/*!\brief One layer of a scalable channel audio config.
+ *
+ * Mirrors `ChannelAudioLayerConfig` in an Audio Element OBU. When
+ * `loudspeaker_layout` is "Expanded", `expanded_loudspeaker_layout` carries
+ * the resolved expanded layout name; it is nullopt otherwise.
+ */
+struct ChannelAudioLayerReport {
+  std::string loudspeaker_layout;  // e.g. "Stereo", "5.1.4", "Expanded".
+  uint8_t loudspeaker_layout_raw;
+  std::optional<std::string> expanded_loudspeaker_layout;
+  std::optional<uint8_t> expanded_loudspeaker_layout_raw;
+  bool output_gain_is_present_flag;
+  bool recon_gain_is_present_flag;
+  uint8_t substream_count;
+  uint8_t coupled_substream_count;
+  uint8_t output_gain_flag;  // 6-bit mask of channels the gain applies to.
+  int16_t output_gain_q7_8;  // Raw signed Q7.8 gain.
+  float output_gain;         // Decoded (raw / 256.0), in dB.
+};
+
+/*!\brief Ambisonics mono config of a scene-based Audio Element OBU. */
+struct AmbisonicsMonoReport {
+  uint8_t output_channel_count;
+  uint8_t substream_count;
+  std::vector<uint8_t> channel_mapping;
+};
+
+/*!\brief Ambisonics projection config of a scene-based Audio Element OBU.
+ *
+ * `demixing_matrix` holds the raw signed 16-bit matrix coefficients in the
+ * order they are coded in the OBU.
+ */
+struct AmbisonicsProjectionReport {
+  uint8_t output_channel_count;
+  uint8_t substream_count;
+  uint8_t coupled_substream_count;
+  std::vector<int16_t> demixing_matrix;
+};
+
+/*!\brief Ambisonics config of a scene-based Audio Element OBU.
+ *
+ * Exactly one of `mono` / `projection` is populated, matching `mode`.
+ * `order` is derived from the config's output channel count: it is set to N
+ * when that count equals (N + 1)^2, and is nullopt when the count is not a
+ * perfect square.
+ */
+struct AmbisonicsReport {
+  std::string mode;  // "mono", "projection", "reserved(N)".
+  uint8_t mode_raw;
+  std::optional<AmbisonicsMonoReport> mono;
+  std::optional<AmbisonicsProjectionReport> projection;
+  std::optional<int> order;
+};
+
+/*!\brief One parameter definition declared by an Audio Element OBU. */
+struct AudioElementParamReport {
+  std::string param_type;  // "mix_gain", "demixing", "recon_gain", etc.
+  uint32_t param_type_raw;
+  uint32_t parameter_id;
+  uint32_t parameter_rate;
+  uint8_t param_definition_mode;
+  uint32_t duration;
+  uint32_t constant_subblock_duration;
+};
+
+/*!\brief Summary of one Audio Element OBU.
+ *
+ * `scalable_layers` is populated for channel-based elements; `ambisonics`
+ * is populated for scene-based elements. The convenience fields at the
+ * bottom duplicate the top-most layer / ambisonics info so summary output
+ * does not need to descend into the per-config structs.
+ */
+struct AudioElementReport {
+  uint32_t id;
+  std::string type;  // "channel_based", "scene_based", "object_based", ...
+  uint8_t type_raw;
+  uint8_t reserved;
+  uint32_t codec_config_id;
+  uint32_t num_substreams;
+  std::vector<uint32_t> substream_ids;
+  std::vector<AudioElementParamReport> params;
+
+  // Channel-based:
+  std::vector<ChannelAudioLayerReport> scalable_layers;
+
+  // Scene-based:
+  std::optional<AmbisonicsReport> ambisonics;
+
+  // Convenience fields (top-most info).
+  std::optional<std::string> channel_layout;
+  // Raw coded `loudspeaker_layout` of the top-most layer: a stable
+  // identifier for gating logic, immune to display-label rewording. When
+  // the layout is "Expanded", `expanded_channel_layout_raw` carries the raw
+  // expanded layout value.
+  std::optional<uint8_t> channel_layout_raw;
+  std::optional<uint8_t> expanded_channel_layout_raw;
+  std::optional<int> ambisonics_order;
+  std::optional<int> ambisonics_channels;
+  // Decoded channel count of the element: for channel-based elements the
+  // channels of the top-most layer (each coupled substream carries two
+  // channels, each non-coupled one, summed across layers); for scene-based
+  // elements the ambisonics output channel count. Unset for object-based
+  // and reserved element types.
+  std::optional<uint32_t> num_channels;
+};
+
+// ---------- Mix Presentation ----------
+
+/*!\brief Common fields shared by every parameter definition. */
+struct ParamDefinitionReport {
+  uint32_t parameter_id;
+  uint32_t parameter_rate;
+  uint8_t param_definition_mode;
+  uint32_t duration;
+  uint32_t constant_subblock_duration;
+};
+
+/*!\brief A mix-gain parameter definition with its default gain.
+ *
+ * `default_mix_gain` is the decoded value of `default_mix_gain_q7_8`
+ * (raw / 256.0), in dB.
+ */
+struct MixGainParamDefinitionReport {
+  ParamDefinitionReport param_definition;
+  int16_t default_mix_gain_q7_8;
+  float default_mix_gain;
+};
+
+/*!\brief Rendering config of one audio element within a sub-mix. */
+struct RenderingConfigReport {
+  std::string
+      headphones_rendering_mode;  // "stereo", "binaural_world_locked", ...
+  uint8_t headphones_rendering_mode_raw;
+  std::string
+      binaural_filter_profile;  // "ambient", "direct", "reverberant", ...
+  uint8_t binaural_filter_profile_raw;
+};
+
+/*!\brief One audio element referenced by a sub-mix. */
+struct SubMixAudioElementReport {
+  uint32_t audio_element_id;
+  std::vector<std::string> localized_element_annotations;
+  RenderingConfigReport rendering_config;
+  MixGainParamDefinitionReport element_mix_gain;
+};
+
+/*!\brief One anchored loudness entry of a loudness info block.
+ *
+ * `anchored_loudness` is the decoded value of `anchored_loudness_q7_8`
+ * (raw / 256.0), in LKFS.
+ */
+struct AnchoredLoudnessElementReport {
+  std::string anchor_element;  // "unknown", "dialogue", "album", "reserved(N)".
+  uint8_t anchor_element_raw;
+  int16_t anchored_loudness_q7_8;
+  float anchored_loudness;
+};
+
+/*!\brief Layout a sub-mix's loudness was measured on.
+ *
+ * `sound_system` is only populated when `layout_type` refers to an ITU-R
+ * BS.2051 sound system ("loudspeakers_ss_convention"); it is nullopt for
+ * other layout types such as binaural.
+ */
+struct LayoutReport {
+  std::string layout_type;  // "loudspeakers_ss_convention", "binaural", ...
+  uint8_t layout_type_raw;
+  std::optional<std::string> sound_system;  // e.g. "7.1.4", "Stereo".
+  std::optional<uint8_t> sound_system_raw;
+};
+
+/*!\brief Loudness information measured on one layout.
+ *
+ * `integrated_loudness` (LKFS), `digital_peak` (dBFS), and `true_peak`
+ * (dBTP) are decoded from their Q7.8 coded forms (raw / 256.0).
+ * `true_peak` is only populated when `true_peak_present` is true.
+ */
+struct LoudnessInfoReport {
+  uint8_t info_type;  // Raw 8-bit mask.
+  bool true_peak_present;
+  bool anchored_loudness_present;
+  bool has_layout_extension;  // Any layout-extension bit of `info_type` set.
+  float integrated_loudness;
+  float digital_peak;
+  std::optional<float> true_peak;
+  std::vector<AnchoredLoudnessElementReport> anchored_loudness_elements;
+};
+
+/*!\brief One (layout, loudness) pair of a sub-mix. */
+struct MixPresentationLayoutReport {
+  LayoutReport loudness_layout;
+  LoudnessInfoReport loudness;
+};
+
+/*!\brief One sub-mix of a Mix Presentation OBU. */
+struct SubMixReport {
+  std::vector<SubMixAudioElementReport> audio_elements;
+  MixGainParamDefinitionReport output_mix_gain;
+  std::vector<MixPresentationLayoutReport> layouts;
+};
+
+/*!\brief One tag of a Mix Presentation Tags block. */
+struct MixPresentationTagReport {
+  std::string tag_name;
+  std::string tag_value;
+};
+
+/*!\brief Summary of one Mix Presentation OBU.
+ *
+ * The convenience fields at the bottom are derived from the first sub-mix
+ * and its first layout so summary output does not need to descend into
+ * `sub_mixes`; consult `sub_mixes` for the full per-layout data.
+ */
+struct MixPresentationReport {
+  uint32_t id;
+  uint32_t count_label;
+  // (language_code, localized_label) pairs.
+  std::vector<std::pair<std::string, std::string>> annotations;
+  uint32_t num_sub_mixes;
+  std::vector<SubMixReport> sub_mixes;
+  std::vector<MixPresentationTagReport> tags;  // Empty if absent.
+
+  // Convenience summary derived from the first sub-mix / first layout.
+  std::vector<std::string> layouts;
+  std::optional<float> integrated_loudness_lkfs;
+  std::optional<float> digital_peak_dbfs;
+  std::optional<float> true_peak_dbfs;
+};
+
+// ---------- Temporal Unit Scan (opt-in) ----------
+
+/*!\brief Mix-gain animation of one parameter subblock.
+ *
+ * The point values are mix gains in dB, reported as raw Q7.8 plus decoded
+ * float pairs.
+ */
+struct MixGainAnimationReport {
+  std::string animation_type;  // "step", "linear", "bezier", "reserved(N)".
+  uint32_t animation_type_raw = 0;
+  int16_t start_point_value_q7_8 = 0;
+  float start_point_value = 0.0f;
+  std::optional<int16_t> end_point_value_q7_8;
+  std::optional<float> end_point_value;
+  std::optional<int16_t> control_point_value_q7_8;
+  std::optional<float> control_point_value;
+  std::optional<uint8_t> control_point_relative_time;  // Raw unsigned Q0.8.
+};
+
+/*!\brief Demixing info of one parameter subblock. */
+struct DemixingInfoReport {
+  std::string dmixp_mode;  // "mode1", "mode2", ..., "reserved(N)".
+  uint8_t dmixp_mode_raw = 0;
+  uint8_t reserved = 0;
+};
+
+/*!\brief Recon gain values for one layer of a scalable channel config. */
+struct ReconGainForLayerReport {
+  uint8_t layer_index;
+  uint32_t recon_gain_flag;         // ULEB128-coded channel bitmask.
+  std::vector<uint8_t> recon_gain;  // Values for channels with the flag set.
+};
+
+/*!\brief Recon gain info of one parameter subblock. */
+struct ReconGainInfoReport {
+  std::vector<ReconGainForLayerReport> layers;
+};
+
+/*!\brief One subblock of a Parameter Block OBU.
+ *
+ * At most one of `mix_gain` / `demixing` / `recon_gain` is populated,
+ * matching the parameter type of the enclosing block.
+ */
+struct ParameterSubblockReport {
+  // Resolved from the block / constant / variable duration rules.
+  uint32_t subblock_duration = 0;
+  std::optional<MixGainAnimationReport> mix_gain;
+  std::optional<DemixingInfoReport> demixing;
+  std::optional<ReconGainInfoReport> recon_gain;
+};
+
+/*!\brief Summary of one Parameter Block OBU seen during the scan. */
+struct ParameterBlockReport {
+  uint32_t parameter_id = 0;
+  std::string param_type;  // Same vocabulary as `AudioElementParamReport`.
+  // Raw coded parameter definition type; 0 with `param_type` "unknown" when
+  // the parameter id was not declared in the descriptors.
+  uint32_t param_type_raw = 0;
+  uint64_t start_timestamp = 0;  // In ticks of the parameter rate.
+  uint64_t end_timestamp = 0;
+  uint32_t duration = 0;
+  uint32_t constant_subblock_duration = 0;
+  std::vector<ParameterSubblockReport> subblocks;
+};
+
+/*!\brief Per-substream audio frame totals accumulated by the scan. */
+struct AudioFrameSummaryReport {
+  uint32_t substream_id = 0;
+  uint32_t codec_config_id = 0;
+  uint32_t frame_count = 0;
+  // Sum of `num_samples_per_frame` across the substream's frames.
+  uint64_t total_samples = 0;
+};
+
+/*!\brief Locator for one temporal unit, emitted by the scan.
+ *
+ * Enables a binary search from a target sample position to the byte offset
+ * of the containing temporal unit (TU), e.g. to seek within a stream.
+ *
+ * `byte_offset_from_scan_start` is measured from the byte immediately after
+ * the last descriptor OBU (i.e. the first temporal unit byte); the absolute
+ * input offset is `ProbeReport::descriptor_bytes_consumed +
+ * byte_offset_from_scan_start`. `start_timestamp` is the raw sample index of
+ * the TU's first sample. `num_samples` is the maximum substream frame size
+ * across the audio frames present in the TU (all substreams share a frame
+ * size in well-formed streams).
+ *
+ * The trim fields give the sample counts to drop from the decoded output of
+ * this TU. Both are read from the first audio frame OBU header seen in the
+ * TU; within a conformant IAMF stream every frame in a TU carries identical
+ * trim values. For Opus the sum of `samples_to_trim_at_start` across the
+ * leading TUs equals the codec config's `pre_skip`. FLAC and LPCM streams
+ * carry zeros.
+ */
+struct TemporalUnitEntry {
+  uint64_t start_timestamp = 0;
+  uint64_t num_samples = 0;
+  size_t byte_offset_from_scan_start = 0;
+  uint32_t samples_to_trim_at_start = 0;
+  uint32_t samples_to_trim_at_end = 0;
+};
+
+/*!\brief Result of the opt-in temporal-unit scan.
+ *
+ * Populated in `ProbeReport::temporal_unit_scan` when
+ * `ProbeOptions::scan_mode` requests a scan. The scan is resilient to
+ * damaged input: OBUs that fail to parse are counted in the
+ * `*_parse_errors` fields and skipped, so callers can tell a healthy file
+ * from a mangled one, and `stopped_reason` records why the scan ended.
+ */
+struct TemporalUnitScanReport {
+  uint32_t temporal_unit_count = 0;
+  uint32_t audio_frame_count = 0;
+  uint32_t parameter_block_count = 0;
+  uint32_t temporal_delimiter_count = 0;
+  // Counts of OBUs whose body failed to parse (or whose parameter id was not
+  // declared in the descriptors) and that the scan therefore skipped.
+  uint32_t audio_frame_parse_errors = 0;
+  uint32_t parameter_block_parse_errors = 0;
+  std::vector<AudioFrameSummaryReport> audio_frames_by_substream;
+  // In stream order. Both stay empty unless `ProbeOptions::scan_mode` is
+  // `ScanMode::kScanFull`.
+  std::vector<ParameterBlockReport> parameter_blocks;
+  std::vector<TemporalUnitEntry> temporal_units;
+  std::optional<uint64_t> total_samples;       // Max substream total.
+  std::optional<double> duration_seconds;      // Derived from total_samples.
+  std::optional<uint32_t> output_sample_rate;  // Rate used for duration.
+  size_t bytes_consumed = 0;
+  // Why the scan ended:
+  // "eof":                  no bytes remained when starting the next OBU.
+  // "truncated":            bytes existed but were insufficient to complete
+  //                         an OBU.
+  // "malformed":            bytes formed a syntactically invalid OBU header,
+  //                         or a buffer operation failed unexpectedly during
+  //                         resync.
+  // "next_ia_sequence":     hit a canonical IA Sequence Header (rewound so
+  //                         the caller can start a fresh scan there).
+  // "scan_budget_exceeded": `ProbeOptions::max_scan_obu_iterations` was hit
+  //                         before reaching the end of the input.
+  // "cancelled":            `ProbeOptions::should_continue` returned false.
+  std::string stopped_reason;
+};
+
+/*!\brief Structured summary of an IA sequence, returned by `Probe`. */
+struct ProbeReport {
+  std::string primary_profile;  // "simple", "base", "base_enhanced", ...
+  uint8_t primary_profile_raw = 0;
+  std::string additional_profile;  // Same vocabulary as `primary_profile`.
+  uint8_t additional_profile_raw = 0;
+  std::vector<CodecConfigReport> codec_configs;
+  std::vector<AudioElementReport> audio_elements;
+  std::vector<MixPresentationReport> mix_presentations;
+  // Bytes of `data` occupied by the descriptor OBUs; temporal units (if
+  // any) start at this offset.
+  size_t descriptor_bytes_consumed = 0;
+  // Descriptors-only duration estimate, derived from codec config metadata
+  // (currently: FLAC STREAMINFO `total_samples_in_stream`) without any
+  // temporal-unit scan. Codec-config-derived and therefore only as
+  // trustworthy as the encoder that wrote it — distinct from the
+  // scan-measured `TemporalUnitScanReport::duration_seconds`, which counts
+  // actual audio frames. Unset when no codec config carries a usable total.
+  std::optional<uint64_t> descriptor_total_samples;
+  std::optional<double> descriptor_duration_seconds;
+  // Populated only when `ProbeOptions::scan_mode` requests a scan.
+  std::optional<TemporalUnitScanReport> temporal_unit_scan;
+};
+
+/*!\brief How far past the descriptor OBUs `Probe` should look. */
+enum class ScanMode {
+  // Parse descriptor OBUs only; any trailing temporal-unit bytes are
+  // ignored and `ProbeReport::temporal_unit_scan` stays unset.
+  kDescriptorsOnly,
+  // Walk temporal units after the descriptor OBUs, accumulating OBU counts,
+  // per-substream sample totals, `total_samples`, and `duration_seconds`.
+  // Parameter-block bodies are skipped without parsing;
+  // `parameter_block_parse_errors` then only counts blocks whose parameter
+  // id could not be peeked or was not declared in the descriptors. The
+  // report stays O(#substreams) instead of O(#TUs): use this for
+  // duration-only probes of large files.
+  kScanCounts,
+  // Everything `kScanCounts` collects, plus the per-TU index
+  // (`temporal_units`) and parsed parameter-block contents
+  // (`parameter_blocks`, with mix-gain animations, demixing info, and recon
+  // gain).
+  kScanFull,
+};
+
+/*!\brief Progress snapshot passed to `ProbeOptions::should_continue`. */
+struct ScanProgress {
+  // Scan bytes consumed so far (measured from the first temporal-unit
+  // byte, like `TemporalUnitScanReport::bytes_consumed`).
+  size_t bytes_consumed = 0;
+  // Temporal units finalized so far.
+  uint32_t temporal_unit_count = 0;
+};
+
+/*!\brief Options controlling what `Probe` extracts. */
+struct ProbeOptions {
+  // How far past the descriptor OBUs to look; see `ScanMode`.
+  ScanMode scan_mode = ScanMode::kDescriptorsOnly;
+  // Optional cancellation/progress hook, consulted once per OBU during the
+  // temporal-unit scan (descriptor parsing is fast and not interruptible).
+  // Return false to stop the scan: the partial results accumulated so far
+  // remain valid, matching the scan's best-effort semantics, and
+  // `stopped_reason` is set to "cancelled".
+  std::function<bool(const ScanProgress&)> should_continue;
+  // Ceiling on scan OBU iterations. The scan is naturally bounded by the
+  // input size (every iteration consumes bytes); this additionally caps
+  // latency on adversarial inputs packed with tiny reserved OBUs. The
+  // default is far beyond any legitimate IAMF file. When hit,
+  // `stopped_reason` is "scan_budget_exceeded".
+  uint64_t max_scan_obu_iterations = 10'000'000;
+};
+
+/*!\brief Parses descriptor OBUs from `data` and returns a structured summary.
+ *
+ * Unlike a decoder, `Probe` touches no audio: it parses the descriptor OBUs
+ * (and, optionally, walks the temporal units) to summarize what the sequence
+ * contains. `data` should contain, at minimum, all descriptor OBUs of an IA
+ * sequence. Trailing temporal unit bytes are permitted and ignored unless
+ * `options.scan_mode` requests a scan, in which case they are walked and
+ * summarized in `ProbeReport::temporal_unit_scan`.
+ *
+ * \param data Bytes of an IA sequence, starting at the IA Sequence Header
+ *        OBU.
+ * \param options Controls the optional temporal-unit scan.
+ * \return A `ProbeReport` summarizing the sequence. Returns
+ *         `kResourceExhausted` if `data` ends before the descriptor OBUs are
+ *         complete (the input may be valid; retry with more bytes), or
+ *         `kInvalidArgument` if the bytes are not a valid IAMF descriptor
+ *         sequence.
+ */
+absl::StatusOr<ProbeReport> Probe(absl::Span<const uint8_t> data,
+                                  ProbeOptions options = {});
+
+/*!\brief Probes an IAMF file on disk.
+ *
+ * Equivalent to reading all of `path` and calling `Probe`, but reads
+ * incrementally through a fixed-size window: a descriptors-only probe
+ * touches just the descriptor bytes, and the optional temporal-unit scan
+ * streams the rest of the file instead of loading it into memory. Use this
+ * to probe files whose size dwarfs their descriptors.
+ *
+ * \param path Path of a file containing an IA sequence, starting at the IA
+ *        Sequence Header OBU.
+ * \param options Controls the optional temporal-unit scan.
+ * \return A `ProbeReport` summarizing the sequence. Returns `kNotFound` if
+ *         the file cannot be opened; otherwise errors as for `Probe`, except
+ *         that truncated descriptors report `kInvalidArgument` (the whole
+ *         file is visible, so more bytes cannot arrive).
+ */
+absl::StatusOr<ProbeReport> ProbeFile(const std::string& path,
+                                      ProbeOptions options = {});
+
+}  // namespace iamf_tools
+
+#endif  // CLI_PROBE_H_

--- a/iamf/cli/probe_json.cc
+++ b/iamf/cli/probe_json.cc
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#include "iamf/cli/probe_json.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "iamf/cli/probe.h"
+
+namespace iamf_tools {
+
+namespace {
+
+// Escapes `s` per RFC 8259: backslash, double-quote, and every byte in
+// U+0000..U+001F must be escaped; higher bytes (including multi-byte UTF-8
+// continuation bytes) pass through unchanged.
+std::string EscapeJson(absl::string_view s) {
+  std::string out;
+  out.reserve(s.size());
+  for (const unsigned char c : s) {
+    switch (c) {
+      case '\\':
+        out.append("\\\\");
+        break;
+      case '"':
+        out.append("\\\"");
+        break;
+      case '\b':
+        out.append("\\b");
+        break;
+      case '\f':
+        out.append("\\f");
+        break;
+      case '\n':
+        out.append("\\n");
+        break;
+      case '\r':
+        out.append("\\r");
+        break;
+      case '\t':
+        out.append("\\t");
+        break;
+      default:
+        if (c < 0x20) {
+          absl::StrAppendFormat(&out, "\\u%04x", c);
+        } else {
+          out.push_back(static_cast<char>(c));
+        }
+    }
+  }
+  return out;
+}
+
+std::string J(absl::string_view s) {
+  return absl::StrCat("\"", EscapeJson(s), "\"");
+}
+
+std::string Bool(bool b) { return b ? "true" : "false"; }
+
+template <typename T>
+std::string Vec(const std::vector<T>& v) {
+  std::vector<std::string> items;
+  items.reserve(v.size());
+  for (const auto& x : v) items.push_back(absl::StrCat(x));
+  return absl::StrCat("[", absl::StrJoin(items, ", "), "]");
+}
+
+std::string StrVec(const std::vector<std::string>& v) {
+  std::vector<std::string> items;
+  items.reserve(v.size());
+  for (const auto& x : v) items.push_back(J(x));
+  return absl::StrCat("[", absl::StrJoin(items, ", "), "]");
+}
+
+std::string JsonCodecConfig(const CodecConfigReport& c) {
+  std::string out =
+      absl::StrCat("{\"id\": ", c.id, ", \"codec_id\": ", J(c.codec_id),
+                   ", \"codec_id_raw\": ", c.codec_id_raw,
+                   ", \"num_samples_per_frame\": ", c.num_samples_per_frame,
+                   ", \"audio_roll_distance\": ", c.audio_roll_distance,
+                   ", \"output_sample_rate\": ", c.output_sample_rate,
+                   ", \"input_sample_rate\": ", c.input_sample_rate,
+                   ", \"bit_depth\": ", c.bit_depth);
+  if (c.opus.has_value()) {
+    const auto& o = *c.opus;
+    absl::StrAppend(&out, ", \"opus\": {\"version\": ", o.version,
+                    ", \"output_channel_count\": ", o.output_channel_count,
+                    ", \"pre_skip\": ", o.pre_skip,
+                    ", \"input_sample_rate\": ", o.input_sample_rate,
+                    ", \"output_gain\": ", o.output_gain,
+                    ", \"output_gain_q7_8\": ", o.output_gain_q7_8,
+                    ", \"mapping_family\": ", o.mapping_family, "}");
+  }
+  if (c.lpcm.has_value()) {
+    const auto& l = *c.lpcm;
+    absl::StrAppend(&out,
+                    ", \"lpcm\": {\"sample_format\": ", J(l.sample_format),
+                    ", \"sample_format_raw\": ", l.sample_format_raw,
+                    ", \"sample_size\": ", l.sample_size,
+                    ", \"sample_rate\": ", l.sample_rate, "}");
+  }
+  if (c.aac.has_value()) {
+    const auto& a = *c.aac;
+    absl::StrAppend(
+        &out,
+        ", \"aac\": {\"object_type_indication\": ", a.object_type_indication,
+        ", \"stream_type\": ", a.stream_type,
+        ", \"upstream\": ", Bool(a.upstream),
+        ", \"reserved\": ", Bool(a.reserved),
+        ", \"buffer_size_db\": ", a.buffer_size_db,
+        ", \"max_bitrate\": ", a.max_bitrate,
+        ", \"average_bit_rate\": ", a.average_bit_rate,
+        ", \"audio_object_type\": ", a.audio_object_type,
+        ", \"sample_frequency_index\": ", J(a.sample_frequency_index),
+        ", \"sample_frequency_index_raw\": ", a.sample_frequency_index_raw,
+        ", \"channel_configuration\": ", a.channel_configuration, "}");
+  }
+  if (c.flac.has_value()) {
+    std::vector<std::string> blocks;
+    blocks.reserve(c.flac->metadata_blocks.size());
+    for (const auto& b : c.flac->metadata_blocks) {
+      std::string item =
+          absl::StrCat("{\"block_type\": ", J(b.block_type),
+                       ", \"block_type_raw\": ", b.block_type_raw);
+      if (b.is_stream_info) {
+        absl::StrAppend(
+            &item, ", \"minimum_block_size\": ", b.minimum_block_size,
+            ", \"maximum_block_size\": ", b.maximum_block_size,
+            ", \"minimum_frame_size\": ", b.minimum_frame_size,
+            ", \"maximum_frame_size\": ", b.maximum_frame_size,
+            ", \"sample_rate\": ", b.sample_rate,
+            ", \"number_of_channels\": ", b.number_of_channels,
+            ", \"bits_per_sample\": ", b.bits_per_sample,
+            ", \"total_samples_in_stream\": ", b.total_samples_in_stream);
+      }
+      absl::StrAppend(&item, "}");
+      blocks.push_back(std::move(item));
+    }
+    absl::StrAppend(&out, ", \"flac\": {\"metadata_blocks\": [",
+                    absl::StrJoin(blocks, ", "), "]}");
+  }
+  absl::StrAppend(&out, "}");
+  return out;
+}
+
+std::string JsonLayer(const ChannelAudioLayerReport& l) {
+  std::string item = absl::StrCat(
+      "{\"loudspeaker_layout\": ", J(l.loudspeaker_layout),
+      ", \"loudspeaker_layout_raw\": ", l.loudspeaker_layout_raw,
+      ", \"substream_count\": ", l.substream_count,
+      ", \"coupled_substream_count\": ", l.coupled_substream_count,
+      ", \"output_gain_is_present_flag\": ",
+      Bool(l.output_gain_is_present_flag),
+      ", \"recon_gain_is_present_flag\": ", Bool(l.recon_gain_is_present_flag),
+      ", \"output_gain_flag\": ", l.output_gain_flag,
+      ", \"output_gain\": ", l.output_gain,
+      ", \"output_gain_q7_8\": ", l.output_gain_q7_8);
+  if (l.expanded_loudspeaker_layout.has_value()) {
+    absl::StrAppend(&item, ", \"expanded_loudspeaker_layout\": ",
+                    J(*l.expanded_loudspeaker_layout));
+  }
+  if (l.expanded_loudspeaker_layout_raw.has_value()) {
+    absl::StrAppend(&item, ", \"expanded_loudspeaker_layout_raw\": ",
+                    *l.expanded_loudspeaker_layout_raw);
+  }
+  absl::StrAppend(&item, "}");
+  return item;
+}
+
+std::string JsonParam(const AudioElementParamReport& p) {
+  return absl::StrCat(
+      "{\"param_type\": ", J(p.param_type),
+      ", \"param_type_raw\": ", p.param_type_raw,
+      ", \"parameter_id\": ", p.parameter_id,
+      ", \"parameter_rate\": ", p.parameter_rate,
+      ", \"param_definition_mode\": ", p.param_definition_mode,
+      ", \"duration\": ", p.duration,
+      ", \"constant_subblock_duration\": ", p.constant_subblock_duration, "}");
+}
+
+std::string JsonAudioElement(const AudioElementReport& a) {
+  std::string out = absl::StrCat("{\"id\": ", a.id, ", \"type\": ", J(a.type),
+                                 ", \"type_raw\": ", a.type_raw,
+                                 ", \"reserved\": ", a.reserved,
+                                 ", \"codec_config_id\": ", a.codec_config_id,
+                                 ", \"num_substreams\": ", a.num_substreams,
+                                 ", \"substream_ids\": ", Vec(a.substream_ids));
+  std::vector<std::string> params;
+  params.reserve(a.params.size());
+  for (const auto& p : a.params) params.push_back(JsonParam(p));
+  absl::StrAppend(&out, ", \"params\": [", absl::StrJoin(params, ", "), "]");
+
+  if (!a.scalable_layers.empty()) {
+    std::vector<std::string> layers;
+    layers.reserve(a.scalable_layers.size());
+    for (const auto& l : a.scalable_layers) layers.push_back(JsonLayer(l));
+    absl::StrAppend(&out, ", \"scalable_layers\": [",
+                    absl::StrJoin(layers, ", "), "]");
+  }
+  if (a.ambisonics.has_value()) {
+    const auto& amb = *a.ambisonics;
+    absl::StrAppend(&out, ", \"ambisonics\": {\"mode\": ", J(amb.mode),
+                    ", \"mode_raw\": ", amb.mode_raw);
+    if (amb.order.has_value()) {
+      absl::StrAppend(&out, ", \"order\": ", *amb.order);
+    }
+    if (amb.mono.has_value()) {
+      const auto& m = *amb.mono;
+      absl::StrAppend(&out, ", \"mono\": {\"output_channel_count\": ",
+                      m.output_channel_count,
+                      ", \"substream_count\": ", m.substream_count,
+                      ", \"channel_mapping\": ", Vec(m.channel_mapping), "}");
+    }
+    if (amb.projection.has_value()) {
+      const auto& p = *amb.projection;
+      absl::StrAppend(
+          &out, ", \"projection\": {\"output_channel_count\": ",
+          p.output_channel_count, ", \"substream_count\": ", p.substream_count,
+          ", \"coupled_substream_count\": ", p.coupled_substream_count,
+          ", \"demixing_matrix\": ", Vec(p.demixing_matrix), "}");
+    }
+    absl::StrAppend(&out, "}");
+  }
+  if (a.channel_layout.has_value()) {
+    absl::StrAppend(&out, ", \"channel_layout\": ", J(*a.channel_layout));
+  }
+  if (a.channel_layout_raw.has_value()) {
+    absl::StrAppend(&out, ", \"channel_layout_raw\": ", *a.channel_layout_raw);
+  }
+  if (a.expanded_channel_layout_raw.has_value()) {
+    absl::StrAppend(&out, ", \"expanded_channel_layout_raw\": ",
+                    *a.expanded_channel_layout_raw);
+  }
+  if (a.ambisonics_order.has_value()) {
+    absl::StrAppend(&out, ", \"ambisonics_order\": ", *a.ambisonics_order);
+  }
+  if (a.ambisonics_channels.has_value()) {
+    absl::StrAppend(&out,
+                    ", \"ambisonics_channels\": ", *a.ambisonics_channels);
+  }
+  if (a.num_channels.has_value()) {
+    absl::StrAppend(&out, ", \"num_channels\": ", *a.num_channels);
+  }
+  absl::StrAppend(&out, "}");
+  return out;
+}
+
+std::string JsonParamDef(const ParamDefinitionReport& d) {
+  return absl::StrCat(
+      "{\"parameter_id\": ", d.parameter_id,
+      ", \"parameter_rate\": ", d.parameter_rate,
+      ", \"param_definition_mode\": ", d.param_definition_mode,
+      ", \"duration\": ", d.duration,
+      ", \"constant_subblock_duration\": ", d.constant_subblock_duration, "}");
+}
+
+std::string JsonMixGain(const MixGainParamDefinitionReport& g) {
+  return absl::StrCat(
+      "{\"param_definition\": ", JsonParamDef(g.param_definition),
+      ", \"default_mix_gain\": ", g.default_mix_gain,
+      ", \"default_mix_gain_q7_8\": ", g.default_mix_gain_q7_8, "}");
+}
+
+std::string JsonLoudness(const LoudnessInfoReport& l) {
+  std::string out = absl::StrCat(
+      "{\"info_type\": ", static_cast<int>(l.info_type),
+      ", \"true_peak_present\": ", Bool(l.true_peak_present),
+      ", \"anchored_loudness_present\": ", Bool(l.anchored_loudness_present),
+      ", \"has_layout_extension\": ", Bool(l.has_layout_extension),
+      ", \"integrated_loudness\": ", l.integrated_loudness,
+      ", \"digital_peak\": ", l.digital_peak);
+  if (l.true_peak.has_value()) {
+    absl::StrAppend(&out, ", \"true_peak\": ", *l.true_peak);
+  }
+  if (!l.anchored_loudness_elements.empty()) {
+    std::vector<std::string> els;
+    els.reserve(l.anchored_loudness_elements.size());
+    for (const auto& e : l.anchored_loudness_elements) {
+      els.push_back(absl::StrCat(
+          "{\"anchor_element\": ", J(e.anchor_element),
+          ", \"anchor_element_raw\": ", e.anchor_element_raw,
+          ", \"anchored_loudness\": ", e.anchored_loudness,
+          ", \"anchored_loudness_q7_8\": ", e.anchored_loudness_q7_8, "}"));
+    }
+    absl::StrAppend(&out, ", \"anchored_loudness_elements\": [",
+                    absl::StrJoin(els, ", "), "]");
+  }
+  absl::StrAppend(&out, "}");
+  return out;
+}
+
+std::string JsonLayout(const MixPresentationLayoutReport& l) {
+  std::string out = absl::StrCat(
+      "{\"loudness_layout\": {\"layout_type\": ",
+      J(l.loudness_layout.layout_type),
+      ", \"layout_type_raw\": ", l.loudness_layout.layout_type_raw);
+  if (l.loudness_layout.sound_system.has_value()) {
+    absl::StrAppend(&out,
+                    ", \"sound_system\": ", J(*l.loudness_layout.sound_system));
+  }
+  if (l.loudness_layout.sound_system_raw.has_value()) {
+    absl::StrAppend(
+        &out, ", \"sound_system_raw\": ", *l.loudness_layout.sound_system_raw);
+  }
+  absl::StrAppend(&out, "}, \"loudness\": ", JsonLoudness(l.loudness), "}");
+  return out;
+}
+
+std::string JsonSubMix(const SubMixReport& s) {
+  std::vector<std::string> aes;
+  aes.reserve(s.audio_elements.size());
+  for (const auto& a : s.audio_elements) {
+    aes.push_back(absl::StrCat(
+        "{\"audio_element_id\": ", a.audio_element_id,
+        ", \"localized_element_annotations\": ",
+        StrVec(a.localized_element_annotations),
+        ", \"rendering_config\": {\"headphones_rendering_mode\": ",
+        J(a.rendering_config.headphones_rendering_mode),
+        ", \"headphones_rendering_mode_raw\": ",
+        a.rendering_config.headphones_rendering_mode_raw,
+        ", \"binaural_filter_profile\": ",
+        J(a.rendering_config.binaural_filter_profile),
+        ", \"binaural_filter_profile_raw\": ",
+        a.rendering_config.binaural_filter_profile_raw, "}",
+        ", \"element_mix_gain\": ", JsonMixGain(a.element_mix_gain), "}"));
+  }
+  std::vector<std::string> layouts;
+  layouts.reserve(s.layouts.size());
+  for (const auto& l : s.layouts) layouts.push_back(JsonLayout(l));
+  return absl::StrCat("{\"audio_elements\": [", absl::StrJoin(aes, ", "), "]",
+                      ", \"output_mix_gain\": ", JsonMixGain(s.output_mix_gain),
+                      ", \"layouts\": [", absl::StrJoin(layouts, ", "), "]}");
+}
+
+std::string JsonMixPresentation(const MixPresentationReport& m) {
+  std::vector<std::string> anns;
+  anns.reserve(m.annotations.size());
+  for (const auto& [lang, label] : m.annotations) {
+    anns.push_back(absl::StrCat("{\"language\": ", J(lang),
+                                ", \"label\": ", J(label), "}"));
+  }
+  std::vector<std::string> subs;
+  subs.reserve(m.sub_mixes.size());
+  for (const auto& s : m.sub_mixes) subs.push_back(JsonSubMix(s));
+  std::vector<std::string> tags;
+  tags.reserve(m.tags.size());
+  for (const auto& t : m.tags) {
+    tags.push_back(absl::StrCat("{\"tag_name\": ", J(t.tag_name),
+                                ", \"tag_value\": ", J(t.tag_value), "}"));
+  }
+  std::string out = absl::StrCat(
+      "{\"id\": ", m.id, ", \"count_label\": ", m.count_label,
+      ", \"num_sub_mixes\": ", m.num_sub_mixes, ", \"annotations\": [",
+      absl::StrJoin(anns, ", "), "]", ", \"sub_mixes\": [",
+      absl::StrJoin(subs, ", "), "]", ", \"tags\": [",
+      absl::StrJoin(tags, ", "), "]", ", \"layouts\": ", StrVec(m.layouts));
+  if (m.integrated_loudness_lkfs.has_value()) {
+    absl::StrAppend(
+        &out, ", \"integrated_loudness_lkfs\": ", *m.integrated_loudness_lkfs);
+  }
+  if (m.digital_peak_dbfs.has_value()) {
+    absl::StrAppend(&out, ", \"digital_peak_dbfs\": ", *m.digital_peak_dbfs);
+  }
+  if (m.true_peak_dbfs.has_value()) {
+    absl::StrAppend(&out, ", \"true_peak_dbfs\": ", *m.true_peak_dbfs);
+  }
+  absl::StrAppend(&out, "}");
+  return out;
+}
+
+std::string JsonTemporalUnitScan(const TemporalUnitScanReport& s) {
+  std::string out = absl::StrCat(
+      "{\"temporal_unit_count\": ", s.temporal_unit_count,
+      ", \"audio_frame_count\": ", s.audio_frame_count,
+      ", \"parameter_block_count\": ", s.parameter_block_count,
+      ", \"temporal_delimiter_count\": ", s.temporal_delimiter_count,
+      ", \"audio_frame_parse_errors\": ", s.audio_frame_parse_errors,
+      ", \"parameter_block_parse_errors\": ", s.parameter_block_parse_errors,
+      ", \"bytes_consumed\": ", s.bytes_consumed,
+      ", \"stopped_reason\": ", J(s.stopped_reason));
+  if (s.total_samples.has_value()) {
+    absl::StrAppend(&out, ", \"total_samples\": ", *s.total_samples);
+  }
+  if (s.output_sample_rate.has_value()) {
+    absl::StrAppend(&out, ", \"output_sample_rate\": ", *s.output_sample_rate);
+  }
+  if (s.duration_seconds.has_value()) {
+    absl::StrAppend(&out, ", \"duration_seconds\": ", *s.duration_seconds);
+  }
+  std::vector<std::string> frames;
+  frames.reserve(s.audio_frames_by_substream.size());
+  for (const auto& f : s.audio_frames_by_substream) {
+    frames.push_back(absl::StrCat("{\"substream_id\": ", f.substream_id,
+                                  ", \"codec_config_id\": ", f.codec_config_id,
+                                  ", \"frame_count\": ", f.frame_count,
+                                  ", \"total_samples\": ", f.total_samples,
+                                  "}"));
+  }
+  absl::StrAppend(&out, ", \"audio_frames_by_substream\": [",
+                  absl::StrJoin(frames, ", "), "]");
+  std::vector<std::string> blocks;
+  blocks.reserve(s.parameter_blocks.size());
+  for (const auto& b : s.parameter_blocks) {
+    std::vector<std::string> subs;
+    subs.reserve(b.subblocks.size());
+    for (const auto& sub : b.subblocks) {
+      std::string item =
+          absl::StrCat("{\"subblock_duration\": ", sub.subblock_duration);
+      if (sub.mix_gain.has_value()) {
+        const auto& m = *sub.mix_gain;
+        absl::StrAppend(
+            &item, ", \"mix_gain\": {\"animation_type\": ", J(m.animation_type),
+            ", \"animation_type_raw\": ", m.animation_type_raw,
+            ", \"start_point_value\": ", m.start_point_value,
+            ", \"start_point_value_q7_8\": ", m.start_point_value_q7_8);
+        if (m.end_point_value.has_value()) {
+          absl::StrAppend(
+              &item, ", \"end_point_value\": ", *m.end_point_value,
+              ", \"end_point_value_q7_8\": ", *m.end_point_value_q7_8);
+        }
+        if (m.control_point_value.has_value()) {
+          absl::StrAppend(
+              &item, ", \"control_point_value\": ", *m.control_point_value,
+              ", \"control_point_value_q7_8\": ", *m.control_point_value_q7_8);
+        }
+        if (m.control_point_relative_time.has_value()) {
+          absl::StrAppend(&item, ", \"control_point_relative_time\": ",
+                          *m.control_point_relative_time);
+        }
+        absl::StrAppend(&item, "}");
+      }
+      if (sub.demixing.has_value()) {
+        absl::StrAppend(&item, ", \"demixing\": {\"dmixp_mode\": ",
+                        J(sub.demixing->dmixp_mode),
+                        ", \"dmixp_mode_raw\": ", sub.demixing->dmixp_mode_raw,
+                        ", \"reserved\": ", sub.demixing->reserved, "}");
+      }
+      if (sub.recon_gain.has_value()) {
+        std::vector<std::string> layers;
+        layers.reserve(sub.recon_gain->layers.size());
+        for (const auto& l : sub.recon_gain->layers) {
+          layers.push_back(absl::StrCat(
+              "{\"layer_index\": ", l.layer_index, ", \"recon_gain_flag\": ",
+              l.recon_gain_flag, ", \"recon_gain\": ", Vec(l.recon_gain), "}"));
+        }
+        absl::StrAppend(&item, ", \"recon_gain\": {\"layers\": [",
+                        absl::StrJoin(layers, ", "), "]}");
+      }
+      absl::StrAppend(&item, "}");
+      subs.push_back(std::move(item));
+    }
+    blocks.push_back(absl::StrCat(
+        "{\"parameter_id\": ", b.parameter_id, ", \"param_type\": ",
+        J(b.param_type), ", \"param_type_raw\": ", b.param_type_raw,
+        ", \"start_timestamp\": ", b.start_timestamp, ", \"end_timestamp\": ",
+        b.end_timestamp, ", \"duration\": ", b.duration,
+        ", \"constant_subblock_duration\": ", b.constant_subblock_duration,
+        ", \"subblocks\": [", absl::StrJoin(subs, ", "), "]}"));
+  }
+  absl::StrAppend(&out, ", \"parameter_blocks\": [",
+                  absl::StrJoin(blocks, ", "), "]}");
+  return out;
+}
+
+}  // namespace
+
+std::string ProbeReportToJson(const ProbeReport& r) {
+  std::vector<std::string> ccs;
+  ccs.reserve(r.codec_configs.size());
+  for (const auto& c : r.codec_configs) {
+    ccs.push_back(absl::StrCat("    ", JsonCodecConfig(c)));
+  }
+  std::vector<std::string> aes;
+  aes.reserve(r.audio_elements.size());
+  for (const auto& a : r.audio_elements) {
+    aes.push_back(absl::StrCat("    ", JsonAudioElement(a)));
+  }
+  std::vector<std::string> mps;
+  mps.reserve(r.mix_presentations.size());
+  for (const auto& m : r.mix_presentations) {
+    mps.push_back(absl::StrCat("    ", JsonMixPresentation(m)));
+  }
+
+  std::string out = "{\n";
+  absl::StrAppend(&out, "  \"primary_profile\": ", J(r.primary_profile), ",\n");
+  absl::StrAppend(&out, "  \"primary_profile_raw\": ", r.primary_profile_raw,
+                  ",\n");
+  absl::StrAppend(&out, "  \"additional_profile\": ", J(r.additional_profile),
+                  ",\n");
+  absl::StrAppend(
+      &out, "  \"additional_profile_raw\": ", r.additional_profile_raw, ",\n");
+  absl::StrAppend(&out, "  \"descriptor_bytes_consumed\": ",
+                  r.descriptor_bytes_consumed, ",\n");
+  if (r.descriptor_total_samples.has_value()) {
+    absl::StrAppend(&out, "  \"descriptor_total_samples\": ",
+                    *r.descriptor_total_samples, ",\n");
+  }
+  if (r.descriptor_duration_seconds.has_value()) {
+    absl::StrAppend(&out, "  \"descriptor_duration_seconds\": ",
+                    *r.descriptor_duration_seconds, ",\n");
+  }
+  absl::StrAppend(&out, "  \"codec_configs\": [\n", absl::StrJoin(ccs, ",\n"),
+                  "\n  ],\n");
+  absl::StrAppend(&out, "  \"audio_elements\": [\n", absl::StrJoin(aes, ",\n"),
+                  "\n  ],\n");
+  absl::StrAppend(&out, "  \"mix_presentations\": [\n",
+                  absl::StrJoin(mps, ",\n"), "\n  ]");
+  if (r.temporal_unit_scan.has_value()) {
+    absl::StrAppend(&out, ",\n  \"temporal_unit_scan\": ",
+                    JsonTemporalUnitScan(*r.temporal_unit_scan));
+  }
+  absl::StrAppend(&out, "\n}\n");
+  return out;
+}
+
+}  // namespace iamf_tools

--- a/iamf/cli/probe_json.h
+++ b/iamf/cli/probe_json.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#ifndef CLI_PROBE_JSON_H_
+#define CLI_PROBE_JSON_H_
+
+#include <string>
+
+#include "iamf/cli/probe.h"
+
+namespace iamf_tools {
+
+/*!\brief Serializes a `ProbeReport` to a JSON object string.
+ *
+ * The output is a single pretty-printed JSON object mirroring the
+ * `ProbeReport` structure (the same shape `probe_main` prints), terminated
+ * by a newline. Optional report fields are omitted when unset. The
+ * serializer lives alongside `ProbeReport` so the JSON shape evolves in the
+ * same commit as the struct; embedders should use it instead of hand-rolling
+ * their own.
+ *
+ * \param report Report to serialize.
+ * \return JSON object string.
+ */
+std::string ProbeReportToJson(const ProbeReport& report);
+
+}  // namespace iamf_tools
+
+#endif  // CLI_PROBE_JSON_H_

--- a/iamf/cli/probe_main.cc
+++ b/iamf/cli/probe_main.cc
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
+#include "absl/log/globals.h"
+#include "absl/log/initialize.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/types/span.h"
+#include "iamf/cli/probe.h"
+#include "iamf/cli/probe_json.h"
+
+ABSL_FLAG(std::string, input_filename, "", "Filename of the input IAMF file.");
+ABSL_FLAG(std::string, format, "text", "Output format: json | text.");
+ABSL_FLAG(std::string, scan, "",
+          "Temporal-unit scan mode: counts | full. \"counts\" accumulates "
+          "OBU counts, per-substream totals, and duration only; much faster "
+          "on large files. \"full\" additionally records the per-TU index "
+          "and parameter-block contents. Empty (the default) skips the "
+          "scan.");
+ABSL_FLAG(bool, duration, false, "Shorthand for --scan=counts.");
+
+namespace {
+
+// ---------- Human-readable text emitter ----------
+
+std::string FormatText(const iamf_tools::ProbeReport& r) {
+  std::string out;
+  absl::StrAppend(&out, "IA Sequence Header:\n");
+  absl::StrAppend(&out, "  primary_profile:    ", r.primary_profile, "\n");
+  absl::StrAppend(&out, "  additional_profile: ", r.additional_profile, "\n");
+  absl::StrAppend(&out, "  descriptor_bytes:   ", r.descriptor_bytes_consumed,
+                  "\n");
+  if (r.descriptor_duration_seconds.has_value()) {
+    absl::StrAppend(&out, "  est_duration_secs:  ",
+                    absl::StrFormat("%.6f", *r.descriptor_duration_seconds),
+                    " (from codec config metadata)\n");
+  }
+  absl::StrAppend(&out, "\n");
+
+  absl::StrAppend(&out, "Codec Configs (", r.codec_configs.size(), "):\n");
+  for (const auto& c : r.codec_configs) {
+    absl::StrAppend(
+        &out, "  - id=", c.id, " codec=", c.codec_id,
+        " frame=", c.num_samples_per_frame, " roll=", c.audio_roll_distance,
+        " in_sr=", c.input_sample_rate, " out_sr=", c.output_sample_rate,
+        " bit_depth=", c.bit_depth, "\n");
+    if (c.opus.has_value()) {
+      const auto& o = *c.opus;
+      absl::StrAppend(&out, "    opus: version=", o.version,
+                      " channels=", o.output_channel_count,
+                      " pre_skip=", o.pre_skip, " in_sr=", o.input_sample_rate,
+                      " out_gain=", o.output_gain,
+                      " mapping_family=", o.mapping_family, "\n");
+    }
+    if (c.lpcm.has_value()) {
+      const auto& l = *c.lpcm;
+      absl::StrAppend(&out, "    lpcm: fmt=", l.sample_format,
+                      " size=", l.sample_size, " rate=", l.sample_rate, "\n");
+    }
+    if (c.aac.has_value()) {
+      const auto& a = *c.aac;
+      absl::StrAppend(&out, "    aac: obj_type=", a.audio_object_type,
+                      " sf=", a.sample_frequency_index,
+                      " ch=", a.channel_configuration,
+                      " avg_bitrate=", a.average_bit_rate, "\n");
+    }
+    if (c.flac.has_value()) {
+      absl::StrAppend(&out, "    flac: ", c.flac->metadata_blocks.size(),
+                      " metadata_blocks\n");
+      for (const auto& b : c.flac->metadata_blocks) {
+        absl::StrAppend(&out, "      - ", b.block_type);
+        if (b.is_stream_info) {
+          absl::StrAppend(&out, " (sr=", b.sample_rate,
+                          " ch=", b.number_of_channels,
+                          " bps=", b.bits_per_sample, ")");
+        }
+        absl::StrAppend(&out, "\n");
+      }
+    }
+  }
+
+  absl::StrAppend(&out, "\nAudio Elements (", r.audio_elements.size(), "):\n");
+  for (const auto& a : r.audio_elements) {
+    absl::StrAppend(&out, "  - id=", a.id, " type=", a.type,
+                    " codec_cfg=", a.codec_config_id,
+                    " substreams=", a.num_substreams);
+    if (a.num_channels.has_value()) {
+      absl::StrAppend(&out, " channels=", *a.num_channels);
+    }
+    if (!a.substream_ids.empty()) {
+      absl::StrAppend(&out, " ids=[", absl::StrJoin(a.substream_ids, ","), "]");
+    }
+    absl::StrAppend(&out, "\n");
+    for (const auto& p : a.params) {
+      absl::StrAppend(&out, "    param: type=", p.param_type,
+                      " id=", p.parameter_id, " rate=", p.parameter_rate,
+                      " duration=", p.duration, "\n");
+    }
+    for (const auto& l : a.scalable_layers) {
+      absl::StrAppend(&out, "    layer: ", l.loudspeaker_layout,
+                      " substreams=", static_cast<int>(l.substream_count),
+                      " coupled=", static_cast<int>(l.coupled_substream_count));
+      if (l.expanded_loudspeaker_layout.has_value()) {
+        absl::StrAppend(&out, " expanded=", *l.expanded_loudspeaker_layout);
+      }
+      if (l.output_gain_is_present_flag) {
+        absl::StrAppend(&out, " output_gain=", l.output_gain,
+                        " flag=", static_cast<int>(l.output_gain_flag));
+      }
+      if (l.recon_gain_is_present_flag) {
+        absl::StrAppend(&out, " recon_gain=yes");
+      }
+      absl::StrAppend(&out, "\n");
+    }
+    if (a.ambisonics.has_value()) {
+      const auto& amb = *a.ambisonics;
+      absl::StrAppend(&out, "    ambisonics: mode=", amb.mode);
+      if (amb.order.has_value()) {
+        absl::StrAppend(&out, " order=", *amb.order);
+      }
+      if (amb.mono.has_value()) {
+        absl::StrAppend(
+            &out,
+            " channels=", static_cast<int>(amb.mono->output_channel_count),
+            " substreams=", static_cast<int>(amb.mono->substream_count));
+      } else if (amb.projection.has_value()) {
+        absl::StrAppend(
+            &out, " channels=",
+            static_cast<int>(amb.projection->output_channel_count),
+            " substreams=", static_cast<int>(amb.projection->substream_count),
+            " coupled=",
+            static_cast<int>(amb.projection->coupled_substream_count));
+      }
+      absl::StrAppend(&out, "\n");
+    }
+  }
+
+  absl::StrAppend(&out, "\nMix Presentations (", r.mix_presentations.size(),
+                  "):\n");
+  for (const auto& m : r.mix_presentations) {
+    absl::StrAppend(&out, "  - id=", m.id, " sub_mixes=", m.num_sub_mixes,
+                    " count_label=", m.count_label, "\n");
+    for (const auto& [lang, label] : m.annotations) {
+      absl::StrAppend(&out, "    annotation: ", lang, " = \"", label, "\"\n");
+    }
+    for (size_t si = 0; si < m.sub_mixes.size(); ++si) {
+      const auto& s = m.sub_mixes[si];
+      absl::StrAppend(&out, "    sub_mix[", si,
+                      "]: audio_elements=", s.audio_elements.size(),
+                      " layouts=", s.layouts.size(), "\n");
+      for (const auto& ae : s.audio_elements) {
+        absl::StrAppend(
+            &out, "      ae_id=", ae.audio_element_id,
+            " headphones=", ae.rendering_config.headphones_rendering_mode,
+            " filter=", ae.rendering_config.binaural_filter_profile,
+            " mix_gain=", ae.element_mix_gain.default_mix_gain, "\n");
+      }
+      for (const auto& l : s.layouts) {
+        const std::string layout_name = l.loudness_layout.sound_system.value_or(
+            l.loudness_layout.layout_type);
+        absl::StrAppend(
+            &out, "      layout: ", layout_name,
+            " loudness: integrated=", l.loudness.integrated_loudness,
+            " peak=", l.loudness.digital_peak);
+        if (l.loudness.true_peak.has_value()) {
+          absl::StrAppend(&out, " true_peak=", *l.loudness.true_peak);
+        }
+        absl::StrAppend(&out, " info_type=0x",
+                        absl::StrFormat("%02x", l.loudness.info_type), "\n");
+      }
+    }
+    for (const auto& t : m.tags) {
+      absl::StrAppend(&out, "    tag: ", t.tag_name, " = ", t.tag_value, "\n");
+    }
+  }
+
+  if (r.temporal_unit_scan.has_value()) {
+    const auto& s = *r.temporal_unit_scan;
+    absl::StrAppend(&out, "\nTemporal Units:\n");
+    absl::StrAppend(&out, "  count:             ", s.temporal_unit_count, "\n");
+    absl::StrAppend(&out, "  audio_frames:      ", s.audio_frame_count, "\n");
+    absl::StrAppend(&out, "  parameter_blocks:  ", s.parameter_block_count,
+                    "\n");
+    absl::StrAppend(&out, "  delimiters:        ", s.temporal_delimiter_count,
+                    "\n");
+    if (s.audio_frame_parse_errors > 0 || s.parameter_block_parse_errors > 0) {
+      absl::StrAppend(
+          &out, "  parse_errors:      frames=", s.audio_frame_parse_errors,
+          " parameter_blocks=", s.parameter_block_parse_errors, "\n");
+    }
+    absl::StrAppend(&out, "  bytes_consumed:    ", s.bytes_consumed, "\n");
+    absl::StrAppend(&out, "  stopped_reason:    ", s.stopped_reason, "\n");
+    if (s.total_samples.has_value()) {
+      absl::StrAppend(&out, "  total_samples:     ", *s.total_samples, "\n");
+    }
+    if (s.duration_seconds.has_value()) {
+      absl::StrAppend(&out, "  duration_seconds:  ",
+                      absl::StrFormat("%.6f", *s.duration_seconds), "\n");
+    }
+    for (const auto& f : s.audio_frames_by_substream) {
+      absl::StrAppend(&out, "  substream id=", f.substream_id,
+                      " codec_cfg=", f.codec_config_id,
+                      " frames=", f.frame_count, " samples=", f.total_samples,
+                      "\n");
+    }
+    for (const auto& b : s.parameter_blocks) {
+      absl::StrAppend(&out, "  block id=", b.parameter_id,
+                      " type=", b.param_type, " ts=[", b.start_timestamp, ",",
+                      b.end_timestamp, ")", " dur=", b.duration,
+                      " subblocks=", b.subblocks.size(), "\n");
+      for (size_t i = 0; i < b.subblocks.size(); ++i) {
+        const auto& sub = b.subblocks[i];
+        absl::StrAppend(&out, "    sub[", i, "] dur=", sub.subblock_duration);
+        if (sub.mix_gain.has_value()) {
+          const auto& m = *sub.mix_gain;
+          absl::StrAppend(&out, " mix_gain=", m.animation_type,
+                          " start=", m.start_point_value);
+          if (m.end_point_value.has_value()) {
+            absl::StrAppend(&out, " end=", *m.end_point_value);
+          }
+          if (m.control_point_value.has_value()) {
+            absl::StrAppend(&out, " ctrl=", *m.control_point_value, "@",
+                            *m.control_point_relative_time);
+          }
+        }
+        if (sub.demixing.has_value()) {
+          absl::StrAppend(&out, " demixing=", sub.demixing->dmixp_mode);
+        }
+        if (sub.recon_gain.has_value()) {
+          absl::StrAppend(&out,
+                          " recon_gain_layers=", sub.recon_gain->layers.size());
+        }
+        absl::StrAppend(&out, "\n");
+      }
+    }
+  }
+  return out;
+}
+
+// Returns a usage hint for input the probe rejected, based on its leading
+// bytes, or an empty string when no common mistake is recognized.
+std::string SniffHint(absl::Span<const uint8_t> head) {
+  // ISO BMFF: a 32-bit box size followed by "ftyp". IAMF usually travels
+  // inside MP4, so this is the most likely real-world mix-up.
+  if (head.size() >= 8 && head[4] == 'f' && head[5] == 't' && head[6] == 'y' &&
+      head[7] == 'p') {
+    return "; this looks like an MP4 file - extract the IAMF track first "
+           "(e.g. with MP4Box or ffmpeg)";
+  }
+  // A leading temporal-unit OBU (types 3..23: parameter block, temporal
+  // delimiter, audio frame) means the stream starts mid-sequence.
+  if (!head.empty()) {
+    const uint8_t obu_type = head[0] >> 3;
+    if (obu_type >= 3 && obu_type <= 23) {
+      return "; the input appears to start mid-stream (a temporal-unit OBU "
+             "comes first; descriptor OBUs, starting with the IA Sequence "
+             "Header, are required)";
+    }
+  }
+  return "";
+}
+
+// Reads the first bytes of `path` for `SniffHint`. Best-effort: returns
+// empty on any I/O problem.
+std::vector<uint8_t> ReadHead(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) return {};
+  std::vector<uint8_t> head(8);
+  in.read(reinterpret_cast<char*>(head.data()),
+          static_cast<std::streamsize>(head.size()));
+  head.resize(static_cast<size_t>(in.gcount()));
+  return head;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  absl::SetProgramUsageMessage(
+      "Probes descriptor OBUs of an IAMF file and prints a summary without "
+      "decoding any audio.\n\n"
+      "  probe_main <input.iamf>\n"
+      "  probe_main --input_filename=<input.iamf>\n"
+      "  ... | probe_main -          (read the stream from stdin)\n\n"
+      "Use --format=json|text to choose the output format, or "
+      "--scan=counts|full to also walk temporal units (per-substream totals "
+      "and duration; \"full\" adds parameter-block contents and a per-TU "
+      "index). See docs/iamf_probe_main.md.");
+  const std::vector<char*> positional_args = absl::ParseCommandLine(argc, argv);
+  absl::InitializeLog();
+  // Suppress the OBU classes' verbose info-level prints; users only want the
+  // probe output.
+  absl::SetStderrThreshold(absl::LogSeverityAtLeast::kWarning);
+
+  // The input may arrive as --input_filename, as a positional argument, or
+  // as "-" for stdin.
+  std::string input_filename = absl::GetFlag(FLAGS_input_filename);
+  if (positional_args.size() > 2) {
+    std::fputs("error: expected at most one positional input file\n", stderr);
+    return EXIT_FAILURE;
+  }
+  if (positional_args.size() == 2) {
+    if (!input_filename.empty()) {
+      std::fputs(
+          "error: pass the input as either --input_filename or a positional "
+          "argument, not both\n",
+          stderr);
+      return EXIT_FAILURE;
+    }
+    input_filename = positional_args[1];
+  }
+  if (input_filename.empty()) {
+    std::fputs(
+        "error: no input; pass a filename (or - for stdin), e.g. "
+        "probe_main input.iamf\n",
+        stderr);
+    return EXIT_FAILURE;
+  }
+  iamf_tools::ProbeOptions options;
+  const std::string scan = absl::GetFlag(FLAGS_scan);
+  if (scan == "full") {
+    options.scan_mode = iamf_tools::ScanMode::kScanFull;
+  } else if (scan == "counts") {
+    options.scan_mode = iamf_tools::ScanMode::kScanCounts;
+  } else if (!scan.empty()) {
+    std::fprintf(stderr, "error: unknown --scan=%s (counts|full)\n",
+                 scan.c_str());
+    return EXIT_FAILURE;
+  }
+  if (absl::GetFlag(FLAGS_duration) &&
+      options.scan_mode == iamf_tools::ScanMode::kDescriptorsOnly) {
+    options.scan_mode = iamf_tools::ScanMode::kScanCounts;
+  }
+  absl::StatusOr<iamf_tools::ProbeReport> report_or;
+  std::vector<uint8_t> head;
+  if (input_filename == "-") {
+    // Stdin is not seekable, so slurp it and probe the buffer. Stdin is
+    // assumed to be in binary mode, which holds on POSIX; a Windows port
+    // would need to switch it explicitly.
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(std::cin)),
+                               std::istreambuf_iterator<char>());
+    if (std::cin.bad()) {
+      // iostreams do not reliably set errno, so no strerror here.
+      std::fputs("error: read of stdin failed\n", stderr);
+      return EXIT_FAILURE;
+    }
+    head.assign(bytes.begin(),
+                bytes.begin() +
+                    static_cast<ptrdiff_t>(std::min<size_t>(bytes.size(), 8)));
+    report_or = iamf_tools::Probe(bytes, options);
+  } else {
+    // `ProbeFile` reads incrementally: descriptors-only probes touch a few
+    // KB of even multi-GB files.
+    head = ReadHead(input_filename);
+    report_or = iamf_tools::ProbeFile(input_filename, options);
+  }
+  if (!report_or.ok()) {
+    std::fprintf(stderr, "error: %s%s\n",
+                 std::string(report_or.status().message()).c_str(),
+                 SniffHint(head).c_str());
+    return EXIT_FAILURE;
+  }
+  const auto& report = *report_or;
+
+  const std::string format = absl::GetFlag(FLAGS_format);
+  std::string out;
+  if (format == "json") {
+    out = iamf_tools::ProbeReportToJson(report);
+  } else if (format == "text") {
+    out = FormatText(report);
+  } else {
+    std::fprintf(stderr, "error: unknown --format=%s (json|text)\n",
+                 format.c_str());
+    return EXIT_FAILURE;
+  }
+  std::fputs(out.c_str(), stdout);
+  return EXIT_SUCCESS;
+}

--- a/iamf/cli/tests/BUILD
+++ b/iamf/cli/tests/BUILD
@@ -599,6 +599,55 @@ cc_test(
 )
 
 cc_test(
+    name = "probe_json_test",
+    srcs = ["probe_json_test.cc"],
+    deps = [
+        ":cli_test_utils",
+        "//iamf/cli:descriptor_obus",
+        "//iamf/cli:probe",
+        "//iamf/cli:probe_json",
+        "//iamf/obu:audio_frame",
+        "//iamf/obu:ia_sequence_header",
+        "//iamf/obu:obu_base",
+        "//iamf/obu:obu_header",
+        "//iamf/obu:types",
+        "@abseil-cpp//absl/status:status_matchers",
+        "@abseil-cpp//absl/types:span",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "probe_test",
+    srcs = ["probe_test.cc"],
+    deps = [
+        ":cli_test_utils",
+        "//iamf/cli:descriptor_obus",
+        "//iamf/cli:probe",
+        "//iamf/cli/user_metadata_builder:iamf_input_layout",
+        "//iamf/obu:audio_element",
+        "//iamf/obu:audio_frame",
+        "//iamf/obu:codec_config",
+        "//iamf/obu:ia_sequence_header",
+        "//iamf/obu:mix_presentation",
+        "//iamf/obu:obu_base",
+        "//iamf/obu:obu_header",
+        "//iamf/obu:parameter_block",
+        "//iamf/obu:parameter_data",
+        "//iamf/obu:types",
+        "//iamf/obu/decoder_config:flac_decoder_config",
+        "//iamf/obu/param_definitions:mix_gain_param_definition",
+        "//iamf/obu/param_definitions:subblock_schedule",
+        "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:status_matchers",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/types:span",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "profile_filter_test",
     srcs = ["profile_filter_test.cc"],
     deps = [

--- a/iamf/cli/tests/probe_json_test.cc
+++ b/iamf/cli/tests/probe_json_test.cc
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#include "iamf/cli/probe_json.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <string>
+#include <vector>
+
+#include "absl/status/status_matchers.h"
+#include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "iamf/cli/descriptor_obus.h"
+#include "iamf/cli/probe.h"
+#include "iamf/cli/tests/cli_test_utils.h"
+#include "iamf/obu/audio_frame.h"
+#include "iamf/obu/ia_sequence_header.h"
+#include "iamf/obu/obu_base.h"
+#include "iamf/obu/obu_header.h"
+#include "iamf/obu/types.h"
+
+namespace iamf_tools {
+namespace {
+
+using ::absl_testing::IsOk;
+using ::testing::HasSubstr;
+
+constexpr DecodedUleb128 kCodecConfigId = 1;
+constexpr DecodedUleb128 kAudioElementId = 2;
+constexpr DecodedUleb128 kSubstreamId = 18;
+constexpr DecodedUleb128 kMixPresentationId = 3;
+constexpr DecodedUleb128 kParameterId = 999;
+constexpr DecodedUleb128 kParameterRate = 48000;
+
+ProbeReport ProbeMinimalIaSequence(ProbeOptions options = {}) {
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddOpusCodecConfigWithId(kCodecConfigId, codec_configs);
+  DescriptorObus::AudioElementsById audio_elements;
+  AddAmbisonicsMonoAudioElementWithSubstreamIds(kAudioElementId, kCodecConfigId,
+                                                {kSubstreamId}, codec_configs,
+                                                audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithAudioElementIds(kMixPresentationId,
+                                           {kAudioElementId}, kParameterId,
+                                           kParameterRate, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  const AudioFrameObu audio_frame(ObuHeader(), kSubstreamId,
+                                  /*audio_frame=*/{1, 2, 3, 4});
+  const auto temporal_unit = SerializeObusExpectOk({&audio_frame});
+  data.insert(data.end(), temporal_unit.begin(), temporal_unit.end());
+
+  auto report = Probe(absl::MakeConstSpan(data), options);
+  EXPECT_THAT(report, IsOk());
+  return *report;
+}
+
+TEST(ProbeReportToJson, EmitsTopLevelObjectWithDescriptorFields) {
+  const std::string json = ProbeReportToJson(ProbeMinimalIaSequence());
+
+  EXPECT_THAT(json, ::testing::StartsWith("{\n"));
+  EXPECT_THAT(json, ::testing::EndsWith("}\n"));
+  EXPECT_THAT(json, HasSubstr("\"primary_profile\": \"simple\""));
+  EXPECT_THAT(json, HasSubstr("\"primary_profile_raw\": 0"));
+  EXPECT_THAT(json, HasSubstr("\"additional_profile\": \"base\""));
+  EXPECT_THAT(json, HasSubstr("\"codec_id\": \"Opus\""));
+  EXPECT_THAT(json, HasSubstr("\"audio_elements\": ["));
+  EXPECT_THAT(json, HasSubstr("\"mix_presentations\": ["));
+  // No scan was requested, so the scan key is absent.
+  EXPECT_THAT(json, ::testing::Not(HasSubstr("\"temporal_unit_scan\"")));
+}
+
+TEST(ProbeReportToJson, EmitsTemporalUnitScanWhenPresent) {
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const std::string json = ProbeReportToJson(ProbeMinimalIaSequence(options));
+
+  EXPECT_THAT(json, HasSubstr("\"temporal_unit_scan\": {"));
+  EXPECT_THAT(json, HasSubstr("\"stopped_reason\": \"eof\""));
+  EXPECT_THAT(json, HasSubstr("\"audio_frames_by_substream\": ["));
+}
+
+TEST(ProbeReportToJson, EscapesStringsPerRfc8259) {
+  ProbeReport report;
+  report.primary_profile = "quote\"backslash\\control\x01";
+  const std::string json = ProbeReportToJson(report);
+  EXPECT_THAT(json, HasSubstr("\"primary_profile\": "
+                              "\"quote\\\"backslash\\\\control\\u0001\""));
+}
+
+}  // namespace
+}  // namespace iamf_tools

--- a/iamf/cli/tests/probe_test.cc
+++ b/iamf/cli/tests/probe_test.cc
@@ -1,0 +1,966 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+#include "iamf/cli/probe.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <ios>
+#include <list>
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "absl/log/check.h"
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "iamf/cli/descriptor_obus.h"
+#include "iamf/cli/tests/cli_test_utils.h"
+#include "iamf/cli/user_metadata_builder/iamf_input_layout.h"
+#include "iamf/obu/audio_element.h"
+#include "iamf/obu/audio_frame.h"
+#include "iamf/obu/codec_config.h"
+#include "iamf/obu/decoder_config/aac_decoder_config.h"
+#include "iamf/obu/decoder_config/flac_decoder_config.h"
+#include "iamf/obu/demixing_info_parameter_data.h"
+#include "iamf/obu/ia_sequence_header.h"
+#include "iamf/obu/mix_gain_parameter_data.h"
+#include "iamf/obu/mix_presentation.h"
+#include "iamf/obu/obu_base.h"
+#include "iamf/obu/obu_header.h"
+#include "iamf/obu/param_definitions/mix_gain_param_definition.h"
+#include "iamf/obu/param_definitions/subblock_schedule.h"
+#include "iamf/obu/parameter_block.h"
+#include "iamf/obu/temporal_delimiter.h"
+#include "iamf/obu/types.h"
+
+namespace iamf_tools {
+namespace {
+
+using ::absl_testing::IsOk;
+using ::absl_testing::StatusIs;
+
+constexpr DecodedUleb128 kCodecConfigId = 1;
+constexpr DecodedUleb128 kAudioElementId = 2;
+constexpr DecodedUleb128 kSubstreamId = 18;
+constexpr DecodedUleb128 kMixPresentationId = 3;
+constexpr DecodedUleb128 kParameterId = 999;
+constexpr DecodedUleb128 kParameterRate = 48000;
+
+// Appends a trailing temporal unit so the descriptor parser has a clear stop.
+void AppendAudioFrame(DecodedUleb128 substream_id, std::vector<uint8_t>* data) {
+  const AudioFrameObu audio_frame(ObuHeader(), substream_id,
+                                  /*audio_frame=*/{1, 2, 3, 4});
+  const auto temporal_unit = SerializeObusExpectOk({&audio_frame});
+  data->insert(data->end(), temporal_unit.begin(), temporal_unit.end());
+}
+
+std::vector<uint8_t> SerializeMinimalIaSequence(size_t* descriptor_size) {
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddOpusCodecConfigWithId(kCodecConfigId, codec_configs);
+  DescriptorObus::AudioElementsById audio_elements;
+  AddAmbisonicsMonoAudioElementWithSubstreamIds(kAudioElementId, kCodecConfigId,
+                                                {kSubstreamId}, codec_configs,
+                                                audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithAudioElementIds(kMixPresentationId,
+                                           {kAudioElementId}, kParameterId,
+                                           kParameterRate, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  *descriptor_size = data.size();
+  AppendAudioFrame(kSubstreamId, &data);
+  return data;
+}
+
+TEST(Probe, EmptyInputReportsResourceExhausted) {
+  // Empty input is indistinguishable from a stream whose bytes have not
+  // arrived yet, so it reports "need more data", not "invalid".
+  const std::vector<uint8_t> empty;
+  EXPECT_THAT(Probe(absl::MakeConstSpan(empty)).status(),
+              StatusIs(absl::StatusCode::kResourceExhausted));
+}
+
+TEST(Probe, TruncatedDescriptorsReportResourceExhausted) {
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto truncated =
+      absl::MakeConstSpan(data).subspan(0, descriptor_size / 2);
+  EXPECT_THAT(Probe(truncated).status(),
+              StatusIs(absl::StatusCode::kResourceExhausted));
+}
+
+TEST(Probe, IncrementalProbingSucceedsOnceDescriptorsAreComplete) {
+  // The kResourceExhausted/kInvalidArgument split exists so callers can
+  // grow the buffer and retry; exercise that pattern.
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+  for (size_t len = 0; len < descriptor_size; len += 16) {
+    const auto report = Probe(absl::MakeConstSpan(data).subspan(0, len));
+    if (report.ok()) {
+      // Parsing may legitimately succeed before `descriptor_size` once all
+      // descriptor OBUs are visible; nothing more to assert.
+      return;
+    }
+    ASSERT_THAT(report.status(),
+                StatusIs(absl::StatusCode::kResourceExhausted));
+  }
+  EXPECT_THAT(Probe(absl::MakeConstSpan(data)), IsOk());
+}
+
+TEST(Probe, NonIamfInputReportsInvalidArgument) {
+  // A codec config OBU arriving before any IA Sequence Header is
+  // structurally invalid, not short.
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  const auto header_bytes = SerializeObusExpectOk({&sequence_header});
+  // Strip the leading IA Sequence Header so a codec config OBU comes first.
+  const auto headerless =
+      absl::MakeConstSpan(data).subspan(header_bytes.size());
+  EXPECT_THAT(Probe(headerless).status(),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(Probe, ReportsProfilesAndDescriptors) {
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  EXPECT_EQ(report->primary_profile, "simple");
+  EXPECT_EQ(report->primary_profile_raw,
+            static_cast<uint8_t>(ProfileVersion::kIamfSimpleProfile));
+  EXPECT_EQ(report->additional_profile, "base");
+  EXPECT_EQ(report->additional_profile_raw,
+            static_cast<uint8_t>(ProfileVersion::kIamfBaseProfile));
+  ASSERT_EQ(report->codec_configs.size(), 1);
+  EXPECT_EQ(report->codec_configs.front().id, kCodecConfigId);
+  EXPECT_EQ(report->codec_configs.front().codec_id, "Opus");
+  // 'Opus' as a big-endian fourcc.
+  EXPECT_EQ(report->codec_configs.front().codec_id_raw, 0x4f707573u);
+  ASSERT_EQ(report->audio_elements.size(), 1);
+  EXPECT_EQ(report->audio_elements.front().id, kAudioElementId);
+  EXPECT_EQ(report->audio_elements.front().type, "scene_based");
+  EXPECT_EQ(report->audio_elements.front().type_raw,
+            1);  // AUDIO_ELEMENT_SCENE_BASED.
+  ASSERT_EQ(report->mix_presentations.size(), 1);
+  EXPECT_EQ(report->mix_presentations.front().id, kMixPresentationId);
+  EXPECT_EQ(report->descriptor_bytes_consumed, descriptor_size);
+}
+
+TEST(Probe, PopulatesOpusDecoderConfig) {
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  ASSERT_EQ(report->codec_configs.size(), 1);
+  const auto& cc = report->codec_configs.front();
+  ASSERT_TRUE(cc.opus.has_value());
+  EXPECT_FALSE(cc.lpcm.has_value());
+  EXPECT_EQ(cc.opus->output_channel_count, 2);
+  EXPECT_EQ(cc.opus->input_sample_rate, 48000);
+  // The raw Q7.8 gain and its decoded float travel together.
+  EXPECT_FLOAT_EQ(cc.opus->output_gain,
+                  static_cast<float>(cc.opus->output_gain_q7_8) / 256.0f);
+}
+
+TEST(Probe, PopulatesAmbisonicsMonoDetails) {
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  ASSERT_EQ(report->audio_elements.size(), 1);
+  const auto& ae = report->audio_elements.front();
+  EXPECT_EQ(ae.type, "scene_based");
+  ASSERT_TRUE(ae.ambisonics.has_value());
+  EXPECT_EQ(ae.ambisonics->mode, "mono");
+  ASSERT_TRUE(ae.ambisonics->mono.has_value());
+  EXPECT_EQ(ae.substream_ids, std::vector<uint32_t>{kSubstreamId});
+  // `num_channels` mirrors the ambisonics output channel count.
+  ASSERT_TRUE(ae.num_channels.has_value());
+  EXPECT_EQ(*ae.num_channels, ae.ambisonics->mono->output_channel_count);
+  EXPECT_FALSE(ae.channel_layout_raw.has_value());
+}
+
+TEST(Probe, PopulatesScalableChannelLayerDetails) {
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddLpcmCodecConfigWithIdAndSampleRate(kCodecConfigId, 48000, codec_configs);
+  DescriptorObus::AudioElementsById audio_elements;
+  AddScalableAudioElementWithSubstreamIds(
+      IamfInputLayout::kStereo, kAudioElementId, kCodecConfigId, {kSubstreamId},
+      codec_configs, audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithConfigurableLayouts(
+      kMixPresentationId, {kAudioElementId}, kParameterId, kParameterRate,
+      {LoudspeakersSsConventionLayout::kSoundSystemA_0_2_0}, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  ASSERT_EQ(report->codec_configs.size(), 1);
+  ASSERT_TRUE(report->codec_configs.front().lpcm.has_value());
+  EXPECT_EQ(report->codec_configs.front().lpcm->sample_rate, 48000);
+
+  ASSERT_EQ(report->audio_elements.size(), 1);
+  const auto& ae = report->audio_elements.front();
+  EXPECT_EQ(ae.type, "channel_based");
+  ASSERT_FALSE(ae.scalable_layers.empty());
+  EXPECT_EQ(ae.scalable_layers.front().loudspeaker_layout, "Stereo");
+  // The raw coded value (LOUDSPEAKER_LAYOUT_STEREO) rides alongside.
+  EXPECT_EQ(ae.scalable_layers.front().loudspeaker_layout_raw, 1);
+  // Top-layer convenience fields: stable layout id and channel count.
+  ASSERT_TRUE(ae.channel_layout_raw.has_value());
+  EXPECT_EQ(*ae.channel_layout_raw, 1);
+  EXPECT_FALSE(ae.expanded_channel_layout_raw.has_value());
+  ASSERT_TRUE(ae.num_channels.has_value());
+  EXPECT_EQ(*ae.num_channels, 2u);  // One coupled substream = stereo.
+
+  ASSERT_EQ(report->mix_presentations.size(), 1);
+  const auto& mp = report->mix_presentations.front();
+  EXPECT_EQ(mp.num_sub_mixes, 1);
+  ASSERT_EQ(mp.sub_mixes.size(), 1);
+  ASSERT_EQ(mp.sub_mixes.front().layouts.size(), 1);
+  EXPECT_EQ(mp.sub_mixes.front()
+                .layouts.front()
+                .loudness_layout.sound_system.value_or(""),
+            "Stereo");
+  ASSERT_EQ(mp.sub_mixes.front().audio_elements.size(), 1);
+  EXPECT_EQ(mp.sub_mixes.front().audio_elements.front().audio_element_id,
+            kAudioElementId);
+}
+
+TEST(Probe, ComputesNumChannelsAcrossScalableLayers) {
+  // Stereo base layer (one coupled substream = 2 channels) plus a 5.1
+  // enhancement layer (one coupled + two mono substreams = 4 channels):
+  // the top layout's channel count is the sum across layers, 6.
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddLpcmCodecConfigWithIdAndSampleRate(kCodecConfigId, 48000, codec_configs);
+  const std::vector<ChannelAudioLayerConfig> layers = {
+      {.loudspeaker_layout = ChannelAudioLayerConfig::kLayoutStereo,
+       .output_gain_is_present_flag = false,
+       .recon_gain_is_present_flag = false,
+       .substream_count = 1,
+       .coupled_substream_count = 1},
+      {.loudspeaker_layout = ChannelAudioLayerConfig::kLayout5_1_ch,
+       .output_gain_is_present_flag = false,
+       .recon_gain_is_present_flag = false,
+       .substream_count = 3,
+       .coupled_substream_count = 1},
+  };
+  const std::vector<DecodedUleb128> substream_ids = {10, 11, 12, 13};
+  auto element = AudioElementObu::CreateForScalableChannelLayout(
+      ObuHeader(), kAudioElementId, /*reserved=*/0, kCodecConfigId,
+      substream_ids,
+      ScalableChannelLayoutConfig{.channel_audio_layer_configs = layers});
+  ASSERT_THAT(element, IsOk());
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithConfigurableLayouts(
+      kMixPresentationId, {kAudioElementId}, kParameterId, kParameterRate,
+      {LoudspeakersSsConventionLayout::kSoundSystemA_0_2_0,
+       LoudspeakersSsConventionLayout::kSoundSystemB_0_5_0},
+      mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  obus.push_back(&*element);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  AppendAudioFrame(substream_ids.front(), &data);
+
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  ASSERT_EQ(report->audio_elements.size(), 1);
+  const auto& ae = report->audio_elements.front();
+  ASSERT_EQ(ae.scalable_layers.size(), 2u);
+  EXPECT_EQ(ae.channel_layout.value_or(""), "5.1");
+  EXPECT_EQ(ae.channel_layout_raw.value_or(0), 2);  // LOUDSPEAKER_LAYOUT_5_1.
+  ASSERT_TRUE(ae.num_channels.has_value());
+  EXPECT_EQ(*ae.num_channels, 6u);
+}
+
+// ---------- Temporal-unit scan tests ----------
+
+// Builds a `MixGainParamDefinition` matching the one inserted into the mix
+// presentation by `AddMixPresentationObuWithAudioElementIds` so we can author
+// parameter blocks against the same parameter ID.
+MixGainParamDefinition MakeMixGainParamDefinitionMode1(
+    uint32_t parameter_id, uint32_t parameter_rate) {
+  // No schedule => `param_definition_mode` of 1; `default_mix_gain_` defaults
+  // to Q7.8 zero.
+  return MixGainParamDefinition(
+      {.parameter_id = parameter_id, .parameter_rate = parameter_rate});
+}
+
+// Builds a Parameter Block OBU with a single mix-gain subblock.
+std::unique_ptr<ParameterBlockObu> MakeMixGainBlock(
+    const MixGainParamDefinition& def, DecodedUleb128 duration,
+    std::variant<AnimationStepInt16, AnimationLinearInt16, AnimationBezierInt16>
+        anim_data) {
+  auto schedule = SubblockSchedule::CreateWithConstantSubblockDuration(
+      /*duration=*/duration, /*constant_subblock_duration=*/duration);
+  CHECK_OK(schedule);
+  auto block = ParameterBlockObu::CreateMode1(ObuHeader(), def, *schedule);
+  block->subblocks_.front() = std::make_unique<MixGainParameterData>(anim_data);
+  return block;
+}
+
+TEST(Probe, TemporalUnitScanDisabledByDefault) {
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  EXPECT_FALSE(report->temporal_unit_scan.has_value());
+}
+
+TEST(Probe, TemporalUnitScanCountsFramesAndComputesDuration) {
+  // `AddOpusCodecConfigWithId` uses 8 samples per frame at 48 kHz. One frame is
+  // appended by `SerializeMinimalIaSequence`; add a second.
+  constexpr uint32_t kNumSamplesPerFrame = 8;
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.audio_frame_count, 2u);
+  EXPECT_EQ(s.temporal_unit_count, 2u);
+  EXPECT_EQ(s.parameter_block_count, 0u);
+  EXPECT_EQ(s.stopped_reason, "eof");
+  ASSERT_EQ(s.audio_frames_by_substream.size(), 1u);
+  EXPECT_EQ(s.audio_frames_by_substream.front().substream_id, kSubstreamId);
+  EXPECT_EQ(s.audio_frames_by_substream.front().frame_count, 2u);
+  EXPECT_EQ(s.audio_frames_by_substream.front().total_samples,
+            2u * kNumSamplesPerFrame);
+  ASSERT_TRUE(s.total_samples.has_value());
+  EXPECT_EQ(*s.total_samples, 2u * kNumSamplesPerFrame);
+  ASSERT_TRUE(s.duration_seconds.has_value());
+  EXPECT_NEAR(*s.duration_seconds, (2.0 * kNumSamplesPerFrame) / 48000.0, 1e-9);
+  // Per-TU index: one entry per TU, contiguous in the raw-sample timeline.
+  ASSERT_EQ(s.temporal_units.size(), 2u);
+  EXPECT_EQ(s.temporal_units[0].start_timestamp, 0u);
+  EXPECT_EQ(s.temporal_units[0].num_samples, kNumSamplesPerFrame);
+  EXPECT_EQ(s.temporal_units[0].byte_offset_from_scan_start, 0u);
+  // The synthetic fixture uses `AppendAudioFrame` defaults; no trim.
+  EXPECT_EQ(s.temporal_units[0].samples_to_trim_at_start, 0u);
+  EXPECT_EQ(s.temporal_units[0].samples_to_trim_at_end, 0u);
+  EXPECT_EQ(s.temporal_units[1].start_timestamp, kNumSamplesPerFrame);
+  EXPECT_EQ(s.temporal_units[1].num_samples, kNumSamplesPerFrame);
+  EXPECT_GT(s.temporal_units[1].byte_offset_from_scan_start, 0u);
+  EXPECT_LT(s.temporal_units[1].byte_offset_from_scan_start, s.bytes_consumed);
+}
+
+TEST(Probe, TemporalUnitScanWithoutDetailsKeepsCountsAndDuration) {
+  constexpr uint32_t kNumSamplesPerFrame = 8;
+  const auto mix_gain_def =
+      MakeMixGainParamDefinitionMode1(kParameterId, kParameterRate);
+  auto block = MakeMixGainBlock(mix_gain_def, /*duration=*/64,
+                                AnimationStepInt16{.start_point_value = 256});
+
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto block_bytes = SerializeObusExpectOk({block.get()});
+  data.insert(data.end(), block_bytes.begin(), block_bytes.end());
+  AppendAudioFrame(kSubstreamId, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanCounts;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  // Counts, totals, and duration match what a detailed scan reports.
+  EXPECT_EQ(s.audio_frame_count, 2u);
+  EXPECT_EQ(s.temporal_unit_count, 2u);
+  EXPECT_EQ(s.parameter_block_count, 1u);
+  EXPECT_EQ(s.parameter_block_parse_errors, 0u);
+  EXPECT_EQ(s.audio_frame_parse_errors, 0u);
+  ASSERT_EQ(s.audio_frames_by_substream.size(), 1u);
+  EXPECT_EQ(s.audio_frames_by_substream.front().total_samples,
+            2u * kNumSamplesPerFrame);
+  ASSERT_TRUE(s.total_samples.has_value());
+  EXPECT_EQ(*s.total_samples, 2u * kNumSamplesPerFrame);
+  ASSERT_TRUE(s.duration_seconds.has_value());
+  EXPECT_NEAR(*s.duration_seconds, (2.0 * kNumSamplesPerFrame) / 48000.0, 1e-9);
+  // The per-TU index and parameter-block contents are not collected.
+  EXPECT_TRUE(s.temporal_units.empty());
+  EXPECT_TRUE(s.parameter_blocks.empty());
+  EXPECT_EQ(s.stopped_reason, "eof");
+}
+
+TEST(Probe, TemporalUnitScanExtractsMixGainStepLinearAndBezier) {
+  const auto mix_gain_def =
+      MakeMixGainParamDefinitionMode1(kParameterId, kParameterRate);
+
+  // Step.
+  auto step_block =
+      MakeMixGainBlock(mix_gain_def, /*duration=*/64,
+                       AnimationStepInt16{.start_point_value = 256});
+  // Linear.
+  auto linear_block = MakeMixGainBlock(
+      mix_gain_def, /*duration=*/64,
+      AnimationLinearInt16{.start_point_value = 10, .end_point_value = 20});
+  // Bezier.
+  auto bezier_block = MakeMixGainBlock(
+      mix_gain_def, /*duration=*/64,
+      AnimationBezierInt16{.start_point_value = -32,
+                           .end_point_value = 128,
+                           .control_point_value = 48,
+                           .control_point_relative_time = 200});
+
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto step_bytes = SerializeObusExpectOk(
+      {step_block.get(), linear_block.get(), bezier_block.get()});
+  data.insert(data.end(), step_bytes.begin(), step_bytes.end());
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  ASSERT_EQ(s.parameter_blocks.size(), 3u);
+
+  // Step.
+  {
+    const auto& b = s.parameter_blocks[0];
+    EXPECT_EQ(b.parameter_id, kParameterId);
+    EXPECT_EQ(b.param_type, "mix_gain");
+    EXPECT_EQ(b.duration, 64u);
+    ASSERT_EQ(b.subblocks.size(), 1u);
+    ASSERT_TRUE(b.subblocks.front().mix_gain.has_value());
+    const auto& mg = *b.subblocks.front().mix_gain;
+    EXPECT_EQ(mg.animation_type, "step");
+    EXPECT_EQ(mg.start_point_value_q7_8, 256);
+    EXPECT_FLOAT_EQ(mg.start_point_value, 1.0f);
+    EXPECT_FALSE(mg.end_point_value_q7_8.has_value());
+    EXPECT_FALSE(mg.end_point_value.has_value());
+  }
+  // Linear.
+  {
+    const auto& b = s.parameter_blocks[1];
+    ASSERT_EQ(b.subblocks.size(), 1u);
+    ASSERT_TRUE(b.subblocks.front().mix_gain.has_value());
+    const auto& mg = *b.subblocks.front().mix_gain;
+    EXPECT_EQ(mg.animation_type, "linear");
+    EXPECT_EQ(mg.start_point_value_q7_8, 10);
+    ASSERT_TRUE(mg.end_point_value_q7_8.has_value());
+    EXPECT_EQ(*mg.end_point_value_q7_8, 20);
+    ASSERT_TRUE(mg.end_point_value.has_value());
+    EXPECT_FLOAT_EQ(*mg.end_point_value, 20.0f / 256.0f);
+  }
+  // Bezier.
+  {
+    const auto& b = s.parameter_blocks[2];
+    ASSERT_EQ(b.subblocks.size(), 1u);
+    ASSERT_TRUE(b.subblocks.front().mix_gain.has_value());
+    const auto& mg = *b.subblocks.front().mix_gain;
+    EXPECT_EQ(mg.animation_type, "bezier");
+    EXPECT_EQ(mg.start_point_value_q7_8, -32);
+    EXPECT_FLOAT_EQ(mg.start_point_value, -32.0f / 256.0f);
+    ASSERT_TRUE(mg.end_point_value_q7_8.has_value());
+    EXPECT_EQ(*mg.end_point_value_q7_8, 128);
+    ASSERT_TRUE(mg.control_point_value_q7_8.has_value());
+    EXPECT_EQ(*mg.control_point_value_q7_8, 48);
+    EXPECT_FLOAT_EQ(*mg.control_point_value, 48.0f / 256.0f);
+    ASSERT_TRUE(mg.control_point_relative_time.has_value());
+    EXPECT_EQ(*mg.control_point_relative_time, 200);
+  }
+
+  // Timestamps advance by `duration` per block for a given parameter id.
+  EXPECT_EQ(s.parameter_blocks[0].start_timestamp, 0u);
+  EXPECT_EQ(s.parameter_blocks[0].end_timestamp, 64u);
+  EXPECT_EQ(s.parameter_blocks[1].start_timestamp, 64u);
+  EXPECT_EQ(s.parameter_blocks[1].end_timestamp, 128u);
+  EXPECT_EQ(s.parameter_blocks[2].start_timestamp, 128u);
+  EXPECT_EQ(s.parameter_blocks[2].end_timestamp, 192u);
+}
+
+TEST(Probe, TemporalUnitScanStopsOnNextIaSequenceHeader) {
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  // Append a second (non-redundant) IA Sequence Header. The scan should stop
+  // cleanly before consuming it so a subsequent caller can start a new scan.
+  const IASequenceHeaderObu second_sequence(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  const auto second_bytes = SerializeObusExpectOk({&second_sequence});
+  data.insert(data.end(), second_bytes.begin(), second_bytes.end());
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  EXPECT_EQ(report->temporal_unit_scan->stopped_reason, "next_ia_sequence");
+}
+
+TEST(Probe, TemporalUnitScanHandlesTruncation) {
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  // Append an audio frame then lop off the last byte to simulate truncation.
+  AppendAudioFrame(kSubstreamId, &data);
+  data.pop_back();
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  EXPECT_EQ(report->temporal_unit_scan->stopped_reason, "truncated");
+}
+
+TEST(Probe, TemporalUnitScanHasZeroParseErrorsWhenHealthy) {
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  EXPECT_EQ(report->temporal_unit_scan->audio_frame_parse_errors, 0u);
+  EXPECT_EQ(report->temporal_unit_scan->parameter_block_parse_errors, 0u);
+}
+
+TEST(Probe, TemporalUnitScanCountsUnknownParameterIdAsParseError) {
+  constexpr DecodedUleb128 kUnknownParameterId = 12345;
+  ASSERT_NE(kUnknownParameterId, kParameterId);
+
+  // Build a parameter block whose parameter_id is not declared in the
+  // descriptor OBUs. The probe should skip the block and bump
+  // `parameter_block_parse_errors` rather than silently drop it.
+  const auto stray_def =
+      MakeMixGainParamDefinitionMode1(kUnknownParameterId, kParameterRate);
+  auto stray_block = MakeMixGainBlock(
+      stray_def, /*duration=*/64, AnimationStepInt16{.start_point_value = 0});
+
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto stray_bytes = SerializeObusExpectOk({stray_block.get()});
+  data.insert(data.end(), stray_bytes.begin(), stray_bytes.end());
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.parameter_block_count, 0u);
+  EXPECT_EQ(s.parameter_block_parse_errors, 1u);
+  EXPECT_TRUE(s.parameter_blocks.empty());
+  EXPECT_EQ(s.stopped_reason, "eof");
+}
+
+TEST(Probe, TemporalUnitScanCountsTemporalDelimiters) {
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const TemporalDelimiterObu delimiter((ObuHeader()));
+  const auto delimiter_bytes = SerializeObusExpectOk({&delimiter});
+  data.insert(data.end(), delimiter_bytes.begin(), delimiter_bytes.end());
+  AppendAudioFrame(kSubstreamId, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.temporal_delimiter_count, 1u);
+  EXPECT_EQ(s.audio_frame_count,
+            2u);  // One from SerializeMinimal, one appended.
+  EXPECT_EQ(s.stopped_reason, "eof");
+}
+
+TEST(Probe, TemporalUnitScanTracksMultipleSubstreams) {
+  constexpr DecodedUleb128 kSubstreamIdA = 11;
+  constexpr DecodedUleb128 kSubstreamIdB = 22;
+
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddOpusCodecConfigWithId(kCodecConfigId, codec_configs);
+  DescriptorObus::AudioElementsById audio_elements;
+  AddAmbisonicsMonoAudioElementWithSubstreamIds(kAudioElementId, kCodecConfigId,
+                                                {kSubstreamIdA, kSubstreamIdB},
+                                                codec_configs, audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithAudioElementIds(kMixPresentationId,
+                                           {kAudioElementId}, kParameterId,
+                                           kParameterRate, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  // Interleave two frames from A with one from B.
+  AppendAudioFrame(kSubstreamIdA, &data);
+  AppendAudioFrame(kSubstreamIdB, &data);
+  AppendAudioFrame(kSubstreamIdA, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.audio_frame_count, 3u);
+  // TU count is bounded by the per-substream maximum.
+  EXPECT_EQ(s.temporal_unit_count, 2u);
+
+  ASSERT_EQ(s.audio_frames_by_substream.size(), 2u);
+  // Substream ids are reported in sorted order.
+  EXPECT_EQ(s.audio_frames_by_substream[0].substream_id, kSubstreamIdA);
+  EXPECT_EQ(s.audio_frames_by_substream[0].frame_count, 2u);
+  EXPECT_EQ(s.audio_frames_by_substream[1].substream_id, kSubstreamIdB);
+  EXPECT_EQ(s.audio_frames_by_substream[1].frame_count, 1u);
+}
+
+TEST(Probe, TemporalUnitScanCancelledByCallback) {
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  AppendAudioFrame(kSubstreamId, &data);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  int calls = 0;
+  options.should_continue = [&calls](const ScanProgress&) {
+    // Allow the first OBU through, then cancel.
+    return ++calls <= 1;
+  };
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.stopped_reason, "cancelled");
+  // Partial results remain valid: exactly one OBU was processed.
+  EXPECT_EQ(s.audio_frame_count, 1u);
+  EXPECT_EQ(calls, 2);
+}
+
+TEST(Probe, TemporalUnitScanReportsProgressToCallback) {
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  ScanProgress last_progress;
+  int calls = 0;
+  options.should_continue = [&](const ScanProgress& progress) {
+    last_progress = progress;
+    ++calls;
+    return true;
+  };
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.stopped_reason, "eof");
+  // One call per OBU plus the final EOF-detecting iteration.
+  EXPECT_GT(calls, 1);
+  // The last call saw all the bytes the scan ultimately consumed and the
+  // first TU already finalized (a repeat substream closes the previous TU).
+  EXPECT_EQ(last_progress.bytes_consumed, s.bytes_consumed);
+  EXPECT_EQ(last_progress.temporal_unit_count, 1u);
+}
+
+TEST(Probe, TemporalUnitScanRespectsIterationBudget) {
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  options.max_scan_obu_iterations = 1;
+  const auto report = Probe(absl::MakeConstSpan(data), options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.stopped_reason, "scan_budget_exceeded");
+  // Only the single budgeted iteration ran.
+  EXPECT_EQ(s.audio_frame_count, 1u);
+}
+
+// ---------- Descriptor coverage ----------
+
+TEST(Probe, ReportsFlacCodecConfig) {
+  constexpr uint32_t kNumSamplesPerFrame = 16;
+  constexpr uint32_t kSampleRate = 48000;
+  constexpr uint8_t kBitsPerSampleMinusOne = 15;  // 16-bit samples.
+
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddFlacCodecConfigWithId(kCodecConfigId, codec_configs);
+  DescriptorObus::AudioElementsById audio_elements;
+  AddScalableAudioElementWithSubstreamIds(
+      IamfInputLayout::kStereo, kAudioElementId, kCodecConfigId, {kSubstreamId},
+      codec_configs, audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithConfigurableLayouts(
+      kMixPresentationId, {kAudioElementId}, kParameterId, kParameterRate,
+      {LoudspeakersSsConventionLayout::kSoundSystemA_0_2_0}, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  ASSERT_EQ(report->codec_configs.size(), 1);
+  const auto& cc = report->codec_configs.front();
+  EXPECT_EQ(cc.codec_id, "FLAC");
+  EXPECT_EQ(cc.num_samples_per_frame, kNumSamplesPerFrame);
+  ASSERT_TRUE(cc.flac.has_value());
+  ASSERT_FALSE(cc.flac->metadata_blocks.empty());
+  const auto& sinfo = cc.flac->metadata_blocks.front();
+  EXPECT_EQ(sinfo.block_type, "StreamInfo");
+  EXPECT_TRUE(sinfo.is_stream_info);
+  EXPECT_EQ(sinfo.sample_rate, kSampleRate);
+  EXPECT_EQ(sinfo.bits_per_sample, kBitsPerSampleMinusOne);
+  EXPECT_EQ(sinfo.minimum_block_size, kNumSamplesPerFrame);
+  EXPECT_EQ(sinfo.maximum_block_size, kNumSamplesPerFrame);
+  // The fixture's STREAMINFO carries no sample total, so no
+  // descriptors-only duration is available.
+  EXPECT_FALSE(report->descriptor_total_samples.has_value());
+  EXPECT_FALSE(report->descriptor_duration_seconds.has_value());
+}
+
+TEST(Probe, ReportsDescriptorDurationFromFlacStreamInfo) {
+  constexpr uint32_t kNumSamplesPerFrame = 16;
+  constexpr uint32_t kSampleRate = 48000;
+  constexpr uint64_t kTotalSamples = 96000;  // Two seconds at 48 kHz.
+
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  auto flac_obu = CodecConfigObu::Create(
+      ObuHeader(), kCodecConfigId,
+      {.codec_id = CodecConfig::kCodecIdFlac,
+       .num_samples_per_frame = kNumSamplesPerFrame,
+       .decoder_config = FlacDecoderConfig(
+           {{{.header = {.block_type = FlacMetaBlockHeader::kFlacStreamInfo},
+              .payload = FlacMetaBlockStreamInfo{
+                  .minimum_block_size =
+                      static_cast<uint16_t>(kNumSamplesPerFrame),
+                  .maximum_block_size =
+                      static_cast<uint16_t>(kNumSamplesPerFrame),
+                  .sample_rate = kSampleRate,
+                  .bits_per_sample = 15,
+                  .total_samples_in_stream = kTotalSamples}}}})});
+  ASSERT_THAT(flac_obu, IsOk());
+  codec_configs.emplace(kCodecConfigId, *std::move(flac_obu));
+  DescriptorObus::AudioElementsById audio_elements;
+  AddScalableAudioElementWithSubstreamIds(
+      IamfInputLayout::kStereo, kAudioElementId, kCodecConfigId, {kSubstreamId},
+      codec_configs, audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithConfigurableLayouts(
+      kMixPresentationId, {kAudioElementId}, kParameterId, kParameterRate,
+      {LoudspeakersSsConventionLayout::kSoundSystemA_0_2_0}, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  // Descriptors-only probe: the duration arrives without any scan.
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  EXPECT_FALSE(report->temporal_unit_scan.has_value());
+  ASSERT_TRUE(report->descriptor_total_samples.has_value());
+  EXPECT_EQ(*report->descriptor_total_samples, kTotalSamples);
+  ASSERT_TRUE(report->descriptor_duration_seconds.has_value());
+  EXPECT_NEAR(*report->descriptor_duration_seconds, 2.0, 1e-9);
+}
+
+TEST(Probe, ReportsAacCodecConfig) {
+  constexpr uint32_t kNumSamplesPerFrame = 1024;
+
+  const IASequenceHeaderObu sequence_header(ObuHeader(),
+                                            ProfileVersion::kIamfSimpleProfile,
+                                            ProfileVersion::kIamfBaseProfile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddAacCodecConfig(kCodecConfigId, kNumSamplesPerFrame,
+                    AudioSpecificConfig::SampleFrequencyIndex::k48000,
+                    codec_configs);
+  DescriptorObus::AudioElementsById audio_elements;
+  AddScalableAudioElementWithSubstreamIds(
+      IamfInputLayout::kStereo, kAudioElementId, kCodecConfigId, {kSubstreamId},
+      codec_configs, audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithConfigurableLayouts(
+      kMixPresentationId, {kAudioElementId}, kParameterId, kParameterRate,
+      {LoudspeakersSsConventionLayout::kSoundSystemA_0_2_0}, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  ASSERT_EQ(report->codec_configs.size(), 1);
+  const auto& cc = report->codec_configs.front();
+  EXPECT_EQ(cc.codec_id, "AAC LC");
+  EXPECT_EQ(cc.num_samples_per_frame, kNumSamplesPerFrame);
+  ASSERT_TRUE(cc.aac.has_value());
+  EXPECT_EQ(cc.aac->audio_object_type, AudioSpecificConfig::kAudioObjectType);
+  EXPECT_EQ(cc.aac->channel_configuration,
+            AudioSpecificConfig::kChannelConfiguration);
+  EXPECT_EQ(cc.aac->sample_frequency_index, "48000");
+}
+
+TEST(Probe, ReportsReservedAndBaseEnhancedProfiles) {
+  const IASequenceHeaderObu sequence_header(
+      ObuHeader(), ProfileVersion::kIamfBaseEnhancedProfile,
+      ProfileVersion::kIamfReserved255Profile);
+  DescriptorObus::CodecConfigsById codec_configs;
+  AddOpusCodecConfigWithId(kCodecConfigId, codec_configs);
+  DescriptorObus::AudioElementsById audio_elements;
+  AddAmbisonicsMonoAudioElementWithSubstreamIds(kAudioElementId, kCodecConfigId,
+                                                {kSubstreamId}, codec_configs,
+                                                audio_elements);
+  DescriptorObus::MixPresentationObus mix_presentations;
+  AddMixPresentationObuWithAudioElementIds(kMixPresentationId,
+                                           {kAudioElementId}, kParameterId,
+                                           kParameterRate, mix_presentations);
+
+  std::list<const ObuBase*> obus = {&sequence_header};
+  for (const auto& [_, obu] : codec_configs) obus.push_back(&obu);
+  for (const auto& [_, element] : audio_elements) obus.push_back(&element.obu);
+  for (const auto& mp : mix_presentations) obus.push_back(&mp);
+  auto data = SerializeObusExpectOk(obus);
+  AppendAudioFrame(kSubstreamId, &data);
+
+  const auto report = Probe(absl::MakeConstSpan(data));
+  ASSERT_THAT(report, IsOk());
+  EXPECT_EQ(report->primary_profile, "base_enhanced");
+  EXPECT_EQ(report->additional_profile, "reserved_255");
+}
+
+// ---------- ProbeFile ----------
+
+// Writes `data` to a fresh file under the test temp dir and returns its path.
+std::string WriteTempIamfFile(const std::string& name,
+                              absl::Span<const uint8_t> data) {
+  const std::string path = absl::StrCat(::testing::TempDir(), "/", name);
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  out.write(reinterpret_cast<const char*>(data.data()),
+            static_cast<std::streamsize>(data.size()));
+  CHECK(out.good());
+  return path;
+}
+
+TEST(ProbeFile, MatchesProbeOnDescriptors) {
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto path = WriteTempIamfFile("probe_file_descriptors.iamf", data);
+
+  const auto from_file = ProbeFile(path);
+  ASSERT_THAT(from_file, IsOk());
+  EXPECT_EQ(from_file->primary_profile, "simple");
+  EXPECT_EQ(from_file->additional_profile, "base");
+  ASSERT_EQ(from_file->codec_configs.size(), 1u);
+  EXPECT_EQ(from_file->codec_configs.front().codec_id, "Opus");
+  EXPECT_EQ(from_file->descriptor_bytes_consumed, descriptor_size);
+  EXPECT_FALSE(from_file->temporal_unit_scan.has_value());
+}
+
+TEST(ProbeFile, ScansTemporalUnits) {
+  constexpr uint32_t kNumSamplesPerFrame = 8;
+  size_t descriptor_size = 0;
+  auto data = SerializeMinimalIaSequence(&descriptor_size);
+  AppendAudioFrame(kSubstreamId, &data);
+  const auto path = WriteTempIamfFile("probe_file_scan.iamf", data);
+
+  ProbeOptions options;
+  options.scan_mode = ScanMode::kScanFull;
+  const auto report = ProbeFile(path, options);
+  ASSERT_THAT(report, IsOk());
+  ASSERT_TRUE(report->temporal_unit_scan.has_value());
+  const auto& s = *report->temporal_unit_scan;
+  EXPECT_EQ(s.audio_frame_count, 2u);
+  EXPECT_EQ(s.temporal_unit_count, 2u);
+  EXPECT_EQ(s.stopped_reason, "eof");
+  ASSERT_TRUE(s.total_samples.has_value());
+  EXPECT_EQ(*s.total_samples, 2u * kNumSamplesPerFrame);
+  ASSERT_EQ(s.temporal_units.size(), 2u);
+}
+
+TEST(ProbeFile, MissingFileReportsNotFound) {
+  EXPECT_THAT(
+      ProbeFile(absl::StrCat(::testing::TempDir(), "/does_not_exist.iamf"))
+          .status(),
+      StatusIs(absl::StatusCode::kNotFound));
+}
+
+TEST(ProbeFile, TruncatedDescriptorsReportInvalidArgument) {
+  // Unlike the span-based `Probe`, the whole file is visible: truncation
+  // cannot be cured by feeding more bytes, so it is invalid input.
+  size_t descriptor_size = 0;
+  const auto data = SerializeMinimalIaSequence(&descriptor_size);
+  const auto path = WriteTempIamfFile(
+      "probe_file_truncated.iamf",
+      absl::MakeConstSpan(data).subspan(0, descriptor_size / 2));
+  EXPECT_THAT(ProbeFile(path).status(),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+}  // namespace
+}  // namespace iamf_tools


### PR DESCRIPTION
## Summary

Adds a **descriptor-OBU probe**: a small library, `iamf_tools::Probe()`, that parses the descriptor OBUs of an IA sequence into a structured `ProbeReport`, plus a `probe_main` command-line tool that prints that report as text or JSON. The probe summarizes profiles, Codec Configs, Audio Elements, and Mix Presentations (including loudness annotations and tags) **without linking any codec decoder**, and can optionally walk the temporal units to report parameter-block contents, per-substream sample totals, and the stream duration.

## Motivation

Inspecting "what's in an `.iamf` file" currently requires a full decode path. A decoder-free, structured reader is useful for:

- inspecting files produced by the encoder,
- debugging malformed or truncated streams (the temporal-unit scan is best-effort and reports *why* it stopped), and
- building tooling that needs IAMF descriptor metadata but should not depend on any codec library.

Because it touches no audio, the probe links only the OBU/descriptor parsing libraries.

## What's added

- `iamf/cli/probe.{h,cc}` — the `Probe()` / `ProbeFile()` API returning a `ProbeReport`. `ProbeFile()` reads incrementally, so a descriptors-only probe touches only a few KB of even a multi-GB file.
- `iamf/cli/probe_json.{h,cc}` — a standalone JSON serializer for `ProbeReport` (no third-party JSON dependency).
- `iamf/cli/probe_main.cc` — the CLI.
- `iamf/cli/tests/probe_test.cc`, `iamf/cli/tests/probe_json_test.cc` — unit tests.
- `docs/iamf_probe_main.md` and a README entry.

## CLI overview

Input may be a positional argument, `--input_filename`, or `-` for stdin. Pointing the tool at an MP4 (IAMF usually travels inside MP4) or at a stream that starts mid-sequence produces a hint explaining the problem.

- `--format=text|json` — output format (default `text`).
- `--scan=counts|full` — optionally walk the temporal units. `counts` reports OBU counts, per-substream totals, and duration with a report size independent of stream length; `full` adds parameter-block contents and a per-temporal-unit index. `--duration` is shorthand for `--scan=counts`.

## Placement

The probe lives in `iamf/cli/` alongside the other CLI tools and the descriptor/OBU libraries it builds on (`descriptor_obu_parser`, `descriptor_obus`). It is a reusable library first (`iamf_tools::Probe()`) with a thin CLI on top, rather than a standalone validation script, so it sits with the rest of the linkable tooling. Happy to move it under `validation/` if maintainers prefer to group inspection tools there.

## Relationship to the `validation/` tools

This is complementary to the recently added `validation/` tooling rather than overlapping with it:

- `iamf_verifier` is an end-to-end *conformance/quality* harness that decodes and renders a test file and compares it against a reference. The probe does no decoding and renders no verdict — it just describes the descriptors.
- `opus_hoa` is an opinionated, Opus-Ambisonics-specific checker (CANONICAL vs CUSTOM). The probe is general and descriptive across all OBU types and codecs; it already surfaces the Ambisonics projection data (`output_channel_count`, `coupled_substream_count`, the demixing matrix, derived order) that such a checker inspects, so it could serve as a descriptive substrate for that kind of policy check. I'm happy to align the two if that's of interest.

## Testing

- `bazel test //iamf/cli/tests:probe_test //iamf/cli/tests:probe_json_test` passes.
- `bazel build //iamf/cli:probe_main` and a manual run against a corpus `.iamf` file produce the expected report.

## Scope

This PR intentionally keeps the initial surface small: the parsing library, JSON serializer, and a `text`/`json` CLI. A follow-up can add a corpus round-trip test (encode → probe → compare against the source `UserMetadata`), modeled on the existing `encoder_main_lib_test`, along with the CLI plumbing it needs. Keeping that separate lets the inspector land on its own merits first.
