### PR TITLE
Decode IEEE float WAVs to left-justified int32 in WavReader

### DIFF
--- a/iamf/cli/tests/wav_reader_test.cc
+++ b/iamf/cli/tests/wav_reader_test.cc
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <fstream>
 #include <ios>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -69,6 +70,53 @@ constexpr absl::string_view kAdmBwfWithOneStereoAndOneMonoObject(
     "</audioObject>"
     "</topLevel>",
     253);
+
+// A mono IEEE float32 WAV (format tag 3) holding the samples
+// {0.0, 0.5, -0.5, 1.0, -1.0, NaN, 1.5, -1.5, +inf}; the last three are
+// out of the normalized [-1.0, 1.0] range to exercise clamping.
+constexpr absl::string_view kMonoIeeeFloat32Wav(
+    "RIFF"
+    "\x48\x00\x00\x00"  // Size of `RIFF` chunk (the whole file).
+    "WAVE"
+    "fmt "
+    "\x10\x00\x00\x00"  // Size of the `fmt ` chunk.
+    "\x03\x00"          // Format tag (IEEE float).
+    "\x01\x00"          // Number of channels.
+    "\x80\xbb\x00\x00"  // Samples per second (48000).
+    "\x00\xee\x02\x00"  // Bytes per second (48000 * 4).
+    "\x04\x00"          // Block align.
+    "\x20\x00"          // Bits per sample (32).
+    "data"
+    "\x24\x00\x00\x00"   // Size of `data` chunk.
+    "\x00\x00\x00\x00"   // 0.0f
+    "\x00\x00\x00\x3f"   // 0.5f
+    "\x00\x00\x00\xbf"   // -0.5f
+    "\x00\x00\x80\x3f"   // 1.0f
+    "\x00\x00\x80\xbf"   // -1.0f
+    "\x00\x00\xc0\x7f"   // NaN
+    "\x00\x00\xc0\x3f"   // 1.5f
+    "\x00\x00\xc0\xbf"   // -1.5f
+    "\x00\x00\x80\x7f",  // +inf
+    80);
+
+// A mono IEEE float64 WAV (format tag 3) holding the samples {0.5, -1.0}.
+constexpr absl::string_view kMonoIeeeFloat64Wav(
+    "RIFF"
+    "\x34\x00\x00\x00"  // Size of `RIFF` chunk (the whole file).
+    "WAVE"
+    "fmt "
+    "\x10\x00\x00\x00"  // Size of the `fmt ` chunk.
+    "\x03\x00"          // Format tag (IEEE float).
+    "\x01\x00"          // Number of channels.
+    "\x80\xbb\x00\x00"  // Samples per second (48000).
+    "\x00\xdc\x05\x00"  // Bytes per second (48000 * 8).
+    "\x08\x00"          // Block align.
+    "\x40\x00"          // Bits per sample (64).
+    "data"
+    "\x10\x00\x00\x00"                   // Size of `data` chunk.
+    "\x00\x00\x00\x00\x00\x00\xe0\x3f"   // 0.5
+    "\x00\x00\x00\x00\x00\x00\xf0\xbf",  // -1.0
+    60);
 
 void CreateFileFromStringView(absl::string_view file_contents,
                               absl::string_view file_path_suffix,
@@ -313,6 +361,43 @@ TEST(WavReader, OneFrame32BitLittleEndian) {
       {0, 82180641, 151850024, 198401618, 214748364, 198401618, 151850024,
        82180641}};
   EXPECT_EQ(wav_reader.buffers_, expected_frame);
+}
+
+TEST(WavReader, OneFrameIeeeFloat32) {
+  const size_t kNumSamplesPerFrame = 9;
+  std::string wav_file_name;
+  CreateFileFromStringView(kMonoIeeeFloat32Wav, ".wav", wav_file_name);
+
+  auto wav_reader = InitAndValidate(wav_file_name, kNumSamplesPerFrame);
+  EXPECT_EQ(wav_reader.bit_depth(), 32);
+
+  // Float samples are normalized to [-1.0, 1.0]; the reader scales them to
+  // the full int32 range. Out-of-range values are clamped and NaN maps to 0.
+  EXPECT_EQ(wav_reader.ReadFrame(), 9);
+  const std::vector<std::vector<int32_t>> kExpectedFrame = {
+      {0, 0x40000000, -0x40000000, std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::min(), 0,
+       std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::min(),
+       std::numeric_limits<int32_t>::max()}};
+  EXPECT_EQ(wav_reader.buffers_, kExpectedFrame);
+}
+
+TEST(WavReader, OneFrameIeeeFloat64) {
+  const size_t kNumSamplesPerFrame = 2;
+  std::string wav_file_name;
+  CreateFileFromStringView(kMonoIeeeFloat64Wav, ".wav", wav_file_name);
+
+  auto wav_reader = InitAndValidate(wav_file_name, kNumSamplesPerFrame);
+  // `bit_depth()` reports the 64-bit source container width, even though the
+  // decoded samples span the full int32 range. Downstream encoder validation
+  // rejects readers whose bit-depth exceeds the codec's, so float64 input is
+  // usable through `WavReader` directly but not the encoder pipeline.
+  EXPECT_EQ(wav_reader.bit_depth(), 64);
+
+  EXPECT_EQ(wav_reader.ReadFrame(), 2);
+  const std::vector<std::vector<int32_t>> kExpectedFrame = {
+      {0x40000000, std::numeric_limits<int32_t>::min()}};
+  EXPECT_EQ(wav_reader.buffers_, kExpectedFrame);
 }
 
 TEST(WavReader, OneFrameAdm) {

--- a/iamf/cli/wav_reader.cc
+++ b/iamf/cli/wav_reader.cc
@@ -13,10 +13,12 @@
 #include "iamf/cli/wav_reader.h"
 
 #include <cerrno>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -32,7 +34,34 @@ namespace iamf_tools {
 
 namespace {
 const int kAudioToTactileFailure = 0;
+
+// Converts one sample of an IEEE float WAV to the left-justified int32
+// convention documented on `WavReader::buffers_`. For float sources
+// `ReadWavSamples` fills the 32-bit destination with raw float values
+// (`ReadWavInfo::sample_format == kFloat`), so `sample_bits` holds a float bit
+// pattern, not an integer sample. The scaling matches audio_to_tactile's
+// `InPlaceFloatToInt32Conversion` (which only runs on the whole-file
+// `ReadWavFile` path): NaN maps to 0 and out-of-range values are clamped.
+int32_t NormalizedFloatBitsToInt32(int32_t sample_bits) {
+  static_assert(sizeof(float) == sizeof(int32_t));
+  float sample_f32;
+  std::memcpy(&sample_f32, &sample_bits, sizeof(sample_f32));
+  if (std::isnan(sample_f32)) {
+    return 0;
+  }
+  sample_f32 *= 2147483648.0f;  // Scale [-1, 1] to the int32 range.
+  // Beware that a 32-bit float cannot represent INT32_MAX exactly;
+  // (float)INT32_MAX == 2147483648.0f, which would overflow if cast.
+  if (sample_f32 >= 2147483648.0f) {
+    return std::numeric_limits<int32_t>::max();
+  }
+  if (sample_f32 <= -2147483648.0f) {
+    return std::numeric_limits<int32_t>::min();
+  }
+  return static_cast<int32_t>(sample_f32);
 }
+
+}  // namespace
 
 absl::StatusOr<WavReader> WavReader::CreateFromFile(
     const std::string& wav_filename, const size_t num_samples_per_frame) {
@@ -112,7 +141,9 @@ size_t WavReader::ReadFrame() {
       break;
     }
     for (int c = 0; c < num_channels; c++) {
-      buffers_[c][t] = buffer_of_one_tick[c];
+      buffers_[c][t] = info_.sample_format == ReadWavInfo::kFloat
+                           ? NormalizedFloatBitsToInt32(buffer_of_one_tick[c])
+                           : buffer_of_one_tick[c];
     }
   }
 

--- a/iamf/cli/wav_reader.h
+++ b/iamf/cli/wav_reader.h
@@ -56,6 +56,10 @@ class WavReader {
 
   /*!\brief Gets the bit-depth of the reader.
    *
+   * Reports the bit-depth of the source samples in the file. For IEEE float
+   * sources this is the container width (32 or 64), not the justification of
+   * the decoded samples in `buffers_`.
+   *
    * \return Bit-depth.
    */
   int bit_depth() const { return info_.bit_depth; }
@@ -78,8 +82,10 @@ class WavReader {
 
   /*!\brief Buffers storing samples in (channel, time) axes.
    *
-   * The samples are left-justified; the upper `bit_depth()` bits represent the
-   * sample, with the remaining lower bits set to 0.
+   * For integer sources the samples are left-justified; the upper
+   * `bit_depth()` bits represent the sample, with the remaining lower bits set
+   * to 0. For IEEE float sources the normalized samples are scaled to the full
+   * `int32_t` range regardless of `bit_depth()`.
    */
   std::vector<std::vector<int32_t>> buffers_;
 


### PR DESCRIPTION
`WavReader::CreateFromFile` forces `destination_alignment_bytes = 4` but never inspects the decoded sample format. For IEEE float sources (format tag 3), audio_to_tactile's `ReadWavSamples` fills the 32-bit destination with raw float values (`ReadWavInfo::sample_format == kFloat`), so `ReadFrame` stored float *bit patterns* directly into the int32 sample buffers. Header parsing succeeds and `WavSampleProvider` validates only bit depth / sample rate / channel IDs, so a float WAV fed to the encoder produced garbage audio while appearing to encode successfully.

### Fix

Convert float samples to the left-justified int32 convention documented on `buffers_`, using the same scaling as audio_to_tactile's `InPlaceFloatToInt32Conversion` (which only runs on the whole-file `ReadWavFile` path this reader does not use): scale [-1, 1] by 2^31, clamp out-of-range values, map NaN to 0. float64 sources are downcast to float32 by the C layer and take the same path.

The docs on `bit_depth()` and `buffers_` now state that for IEEE float sources `bit_depth()` reports the source container width (32 or 64) while the decoded samples span the full int32 range. As before this change, `WavSampleProvider` rejects readers whose bit depth exceeds the codec's, so float64 input works through `WavReader` directly but not the encoder pipeline; float32 now encodes correctly.

### Tests

Regression tests with hand-crafted mono float32/float64 fixtures cover scaling, clamping (at +/-1.0 and for out-of-range 1.5, -1.5, +inf), and NaN. Both tests fail without the fix — float bit patterns surface verbatim, e.g. 0.5f reads as `0x3F000000` instead of `0x40000000`.

Tested: `bazel test //iamf/cli/tests:wav_reader_test //iamf/cli/tests:wav_sample_provider_test //iamf/cli/tests:wav_writer_test` -> 3/3 pass on top of current `main`.