### PR TITLE
Add an optional CMake build path for Bazel-unavailable environments (#75)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,51 @@
+name: cmake
+
+# Keeps the optional CMake build path (iamf-tools#75) honest: builds the three
+# CLIs from a clean checkout on Linux, then exercises them — probe, decode, and
+# a full encode -> probe -> decode round-trip — on in-tree test data. This
+# workflow is self-contained: removing it (plus CMakeLists.txt and
+# build_cmake.sh) removes the CMake path entirely.
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  linux-amd64-cmake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake pkg-config g++ \
+            libopus-dev libflac-dev libexpat1-dev libeigen3-dev
+      - name: Build (CMake path)
+        run: ./build_cmake.sh "$RUNNER_TEMP/cmake-build"
+      - name: Smoke test (probe, decode, encode round-trip on in-tree data)
+        run: |
+          set -eux
+          BIN="$RUNNER_TEMP/cmake-build/src/build-iamf"
+          # Probe: parse descriptors of two in-tree IAMF files.
+          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf
+          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/tones_100ms_3OA_stereo_opus.iamf
+          # Decode: render an in-tree 5.1 Opus file; output must be non-empty.
+          "$BIN/decoder_main" \
+            --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf \
+            --output_filename="$RUNNER_TEMP/smoke_dec.wav"
+          test -s "$RUNNER_TEMP/smoke_dec.wav"
+          # Encode round-trip: encode an in-tree test vector, then probe and
+          # decode the result with the same freshly built tools.
+          mkdir -p "$RUNNER_TEMP/smoke_enc"
+          "$BIN/encoder_main" \
+            --user_metadata_filename=iamf/cli/testdata/test_000002.textproto \
+            --input_wav_directory=iamf/cli/testdata \
+            --output_iamf_directory="$RUNNER_TEMP/smoke_enc"
+          "$BIN/probe_main" --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf"
+          "$BIN/decoder_main" \
+            --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf" \
+            --output_filename="$RUNNER_TEMP/smoke_enc_dec.wav"
+          test -s "$RUNNER_TEMP/smoke_enc_dec.wav"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,125 @@
+# Optional CMake build path for the encoder_main / decoder_main / probe_main
+# CLIs, for environments where Bazel is unavailable (registry-restricted
+# networks, no BCR / release-archive access). See iamf-tools#75.
+#
+# This is NOT the supported build; Bazel remains the build system of record
+# (see docs/build_instructions.md). This file is written from scratch against
+# the Bazel BUILD graph; no Bazel-generated content is used or derived.
+#
+# Invoke via ./build_cmake.sh (which clones and builds the dependencies, then
+# configures this file with IAMF_CMAKE_DEPS_ROOT pointing at those checkouts).
+# Dependency pins mirror MODULE.bazel; move them forward as upstream moves.
+cmake_minimum_required(VERSION 3.22)
+project(iamf_tools LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_compile_options(-Wno-sign-compare)
+
+set(IAMF ${CMAKE_CURRENT_SOURCE_DIR})
+set(IAMF_CMAKE_DEPS_ROOT "" CACHE PATH
+    "Directory holding the dependency checkouts and shims (populated by build_cmake.sh)")
+if(NOT IAMF_CMAKE_DEPS_ROOT OR NOT EXISTS ${IAMF_CMAKE_DEPS_ROOT})
+  message(FATAL_ERROR
+      "IAMF_CMAKE_DEPS_ROOT is not set (or does not exist). This build path is "
+      "driven by ./build_cmake.sh, which clones the dependencies and passes "
+      "-DIAMF_CMAKE_DEPS_ROOT=<deps dir>. Run ./build_cmake.sh [ROOT] instead "
+      "of invoking cmake directly.")
+endif()
+set(SRC ${IAMF_CMAKE_DEPS_ROOT})
+
+find_package(absl REQUIRED CONFIG)
+find_package(utf8_range CONFIG)          # exported by protobuf install
+find_package(protobuf REQUIRED CONFIG)
+
+find_library(OPUS_LIB opus REQUIRED)
+find_library(FLAC_LIB FLAC REQUIRED)
+find_library(EXPAT_LIB expat REQUIRED)
+
+# ---------------- FDK-AAC (exact upstream pin, own CMake) -------------------
+# Non-recursive on purpose: lib*/src/{arm,mips,x86}/ hold #include-only
+# assembly specializations that do not compile standalone.
+file(GLOB FDK_SRCS ${SRC}/fdk_aac/lib*/src/*.cpp)
+add_library(fdk_aac_static STATIC ${FDK_SRCS})
+file(GLOB FDK_INC_DIRS ${SRC}/fdk_aac/lib*/include)
+target_include_directories(fdk_aac_static PUBLIC ${FDK_INC_DIRS} ${SRC}/fdk_aac)
+
+# ---------------- pffft ------------------------------------------------------
+# marton78/pffft mirror keeps sources under src/ (upstream jpommier keeps them
+# at repo root); pffft_common.c provides the shared aligned-malloc helpers.
+add_library(pffft_static STATIC ${SRC}/pffft/src/pffft.c ${SRC}/pffft/src/pffft_common.c)
+target_include_directories(pffft_static PUBLIC
+    ${SRC}/pffft/src ${SRC}/pffft/include/pffft)
+
+# ---------------- audio-to-tactile :dsp -------------------------------------
+file(GLOB A2T_SRCS ${SRC}/audio_to_tactile/src/dsp/*.c)
+add_library(a2t_dsp STATIC ${A2T_SRCS})
+target_include_directories(a2t_dsp PUBLIC ${SRC}/audio_to_tactile/src ${SRC}/audio_to_tactile)
+target_link_libraries(a2t_dsp PUBLIC m)
+
+# ---------------- loudness_ebur128 ------------------------------------------
+file(GLOB EBUR_SRCS ${SRC}/loudness_ebur128/src/*.cc)
+add_library(ebur128_analyzer STATIC ${EBUR_SRCS})
+target_include_directories(ebur128_analyzer PUBLIC
+    ${SRC}/loudness_ebur128 ${SRC}/loudness_ebur128/src)
+target_link_libraries(ebur128_analyzer PUBLIC absl::status absl::statusor
+    absl::strings absl::span)
+
+# ---------------- OBR (binaural renderer) -----------------------------------
+file(GLOB_RECURSE OBR_SRCS ${SRC}/obr/obr/*.cc)
+list(FILTER OBR_SRCS EXCLUDE REGEX "/tests?/|_test\\.cc|test_util\\.cc|/cli/")
+add_library(obr_lib STATIC ${OBR_SRCS})
+target_include_directories(obr_lib PUBLIC ${SRC}/obr /usr/include/eigen3)
+target_link_libraries(obr_lib PUBLIC pffft_static a2t_dsp
+    absl::log absl::check absl::status absl::statusor absl::strings
+    absl::flat_hash_map absl::span)
+
+# ---------------- proto codegen ---------------------------------------------
+file(GLOB IAMF_PROTOS ${IAMF}/iamf/cli/proto/*.proto)
+set(PROTO_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/proto_gen)
+file(MAKE_DIRECTORY ${PROTO_GEN_DIR})
+set(PROTO_SRCS "")
+foreach(P ${IAMF_PROTOS})
+  file(RELATIVE_PATH REL ${IAMF} ${P})
+  string(REPLACE ".proto" ".pb.cc" GEN_CC ${PROTO_GEN_DIR}/${REL})
+  string(REPLACE ".proto" ".pb.h"  GEN_H  ${PROTO_GEN_DIR}/${REL})
+  add_custom_command(
+    OUTPUT ${GEN_CC} ${GEN_H}
+    COMMAND protobuf::protoc --proto_path=${IAMF} --cpp_out=${PROTO_GEN_DIR} ${REL}
+    DEPENDS ${P} protobuf::protoc
+    WORKING_DIRECTORY ${IAMF})
+  list(APPEND PROTO_SRCS ${GEN_CC})
+endforeach()
+add_library(iamf_protos STATIC ${PROTO_SRCS})
+target_include_directories(iamf_protos PUBLIC ${PROTO_GEN_DIR})
+target_link_libraries(iamf_protos PUBLIC protobuf::libprotobuf)
+
+# ---------------- iamf-tools core -------------------------------------------
+file(GLOB_RECURSE IAMF_SRCS ${IAMF}/iamf/*.cc)
+list(FILTER IAMF_SRCS EXCLUDE REGEX "/tests/|_test\\.cc|_fuzz|_benchmark")
+list(FILTER IAMF_SRCS EXCLUDE REGEX "encoder_main\\.cc|decoder_main\\.cc|probe_main\\.cc|adm_to_user_metadata_main\\.cc")
+add_library(iamf_core STATIC ${IAMF_SRCS})
+target_include_directories(iamf_core PUBLIC
+    ${IAMF}
+    ${SRC}/protobuf              # bazel-style "src/google/protobuf/..." includes
+    ${SRC}/shims/flac            # "include/FLAC/..."
+    ${SRC}/shims/opus            # "include/opus.h"
+    ${SRC}/shims/expat           # "expat/lib/expat.h"
+    /usr/include/eigen3)
+target_link_libraries(iamf_core PUBLIC
+    iamf_protos ebur128_analyzer obr_lib a2t_dsp fdk_aac_static
+    ${OPUS_LIB} ${FLAC_LIB} ${EXPAT_LIB}
+    absl::base absl::log absl::log_initialize absl::log_globals absl::check
+    absl::flags absl::flags_parse absl::flags_usage
+    absl::status absl::statusor absl::strings absl::str_format
+    absl::flat_hash_map absl::flat_hash_set absl::node_hash_map
+    absl::span absl::optional absl::time absl::synchronization
+    absl::memory absl::random_random absl::die_if_null absl::cleanup
+    absl::no_destructor absl::overload absl::any_invocable)
+
+foreach(TOOL encoder_main decoder_main probe_main)
+  add_executable(${TOOL} ${IAMF}/iamf/cli/${TOOL}.cc)
+  target_link_libraries(${TOOL} PRIVATE iamf_core)
+endforeach()

--- a/build_cmake.sh
+++ b/build_cmake.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# build_cmake.sh — optional CMake build path for encoder_main / decoder_main /
+# probe_main, for environments where Bazel is unavailable (registry-restricted
+# networks: git clone allowed; Bazel / BCR / release archives blocked).
+# See iamf-tools#75. Bazel remains the supported build system of record.
+#
+# Written from scratch against the Bazel BUILD graph; no Bazel-generated
+# content is used or derived.
+#
+# Dependency pins mirror MODULE.bazel exactly, with two stated exceptions:
+#   - pffft: MODULE.bazel pins jpommier's bitbucket repo (d7a4c020); this path
+#     uses the marton78 GitHub mirror at a fixed commit (a4b03590), because
+#     restricted environments that motivate this build path typically allow
+#     github.com only. The mirror keeps sources under src/.
+#   - opus / flac / expat / eigen: satisfied from system packages rather than
+#     source pins (header shims below provide the Bazel-style include paths).
+# Move the pins forward as MODULE.bazel moves.
+#
+# Usage:
+#   ./build_cmake.sh [ROOT]   # ROOT defaults to ./build (gitignored is fine;
+#                             # nothing under iamf/ is written)
+# Requirements (Debian/Ubuntu names): cmake pkg-config git g++
+#   libopus-dev libflac-dev libexpat1-dev libeigen3-dev
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${1:-$(pwd)/build}"
+SRC="$ROOT/src"
+DEPS="$ROOT/deps"
+LOG="$ROOT/logs"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 2)}"
+mkdir -p "$SRC" "$DEPS" "$LOG"
+git config --global advice.detachedHead false 2>/dev/null || true
+
+stage() { echo "=== $1 [$(date +%H:%M:%S)] ==="; }
+
+clone() { # name url ref mode   (mode: tag = shallow at tag; commit = shallow fetch by sha)
+  local name="$1" url="$2" ref="$3" mode="$4" rc=1
+  if [ -d "$SRC/$name/.git" ]; then echo "clone $name: exists"; return 0; fi
+  case "$mode" in
+    tag)
+      git clone --depth 1 --branch "$ref" "$url" "$SRC/$name" > "$LOG/clone-$name.log" 2>&1
+      rc=$?
+      if [ "$rc" -ne 0 ]; then
+        # Fallback for hosts where shallow tag clones fail: full clone, then
+        # check out the SAME ref — the pin is preserved either way.
+        rm -rf "${SRC:?}/${name:?}"
+        git clone "$url" "$SRC/$name" >> "$LOG/clone-$name.log" 2>&1 && \
+          git -C "$SRC/$name" checkout "$ref" >> "$LOG/clone-$name.log" 2>&1
+        rc=$?
+      fi
+      ;;
+    commit)
+      git init -q "$SRC/$name" > "$LOG/clone-$name.log" 2>&1 && \
+        git -C "$SRC/$name" remote add origin "$url" >> "$LOG/clone-$name.log" 2>&1 && \
+        git -C "$SRC/$name" fetch --depth 1 origin "$ref" >> "$LOG/clone-$name.log" 2>&1 && \
+        git -C "$SRC/$name" checkout -q FETCH_HEAD >> "$LOG/clone-$name.log" 2>&1
+      rc=$?
+      ;;
+    *)
+      echo "clone $name: bad mode '$mode'" >&2
+      return 1
+      ;;
+  esac
+  if [ "$rc" -eq 0 ]; then
+    echo "clone $name: OK"
+  else
+    echo "clone $name: FAILED (see $LOG/clone-$name.log)"
+    return 1
+  fi
+}
+
+# ---------- S1: dependency clones (pins mirror MODULE.bazel; see header) ----------
+stage "S1 clones"
+clone abseil-cpp       https://github.com/abseil/abseil-cpp        20260107.1 tag    || exit 1
+clone protobuf         https://github.com/protocolbuffers/protobuf v33.5      tag    || exit 1
+clone fdk_aac          https://github.com/mstorsjo/fdk-aac         ee76460efbdb147e26d804c798949c23f174460b commit || exit 1
+clone loudness_ebur128 https://github.com/google/loudness_ebur128  e9e73147637db60dc742cba8a611a37dd72b14b5 commit || exit 1
+clone obr              https://github.com/google/obr               478dc7c752d5eccae534635139ff0253eee3a14a commit || exit 1
+clone audio_to_tactile https://github.com/google/audio-to-tactile  d3f449fdfd8cfe4a845d0ae244fce2a0bca34a15 commit || exit 1
+clone pffft            https://github.com/marton78/pffft           a4b03590cc2a4bea56f9721996e3057835799179 commit || exit 1
+( cd "$SRC/protobuf" && git submodule update --init --depth 1 third_party/jsoncpp 2>/dev/null; true )
+
+# ---------- S2: header shims for Bazel-style repo-relative includes ----------
+stage "S2 shims"
+mkdir -p "$SRC/shims/flac/include" "$SRC/shims/opus/include" "$SRC/shims/expat/expat/lib"
+ln -sf /usr/include/FLAC "$SRC/shims/flac/include/FLAC"
+for h in /usr/include/opus/*.h; do ln -sf "$h" "$SRC/shims/opus/include/"; done
+ln -sf /usr/include/expat.h          "$SRC/shims/expat/expat/lib/expat.h"
+ln -sf /usr/include/expat_external.h "$SRC/shims/expat/expat/lib/expat_external.h"
+ln -sf /usr/include/expat_config.h   "$SRC/shims/expat/expat/lib/expat_config.h" 2>/dev/null || true
+
+# ---------- S3: abseil (static, C++20, propagate std) ----------
+stage "S3 abseil"
+cmake -S "$SRC/abseil-cpp" -B "$SRC/build-absl" -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$DEPS" -DCMAKE_CXX_STANDARD=20 -DABSL_PROPAGATE_CXX_STD=ON \
+  -DBUILD_SHARED_LIBS=OFF -DABSL_BUILD_TESTING=OFF > "$LOG/absl-cfg.log" 2>&1 || { echo "ABSL CFG FAIL"; exit 1; }
+cmake --build "$SRC/build-absl" -j"$JOBS" --target install > "$LOG/absl-build.log" 2>&1 || { echo "ABSL BUILD FAIL"; exit 1; }
+
+# ---------- S4: protobuf (uses the abseil we just installed; protoc >=27 for edition 2023) ----------
+stage "S4 protobuf"
+cmake -S "$SRC/protobuf" -B "$SRC/build-protobuf" -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$DEPS" -DCMAKE_PREFIX_PATH="$DEPS" -DCMAKE_CXX_STANDARD=20 \
+  -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package \
+  -Dprotobuf_BUILD_SHARED_LIBS=OFF > "$LOG/pb-cfg.log" 2>&1 || { echo "PB CFG FAIL"; exit 1; }
+cmake --build "$SRC/build-protobuf" -j"$JOBS" --target install > "$LOG/pb-build.log" 2>&1 || { echo "PB BUILD FAIL"; exit 1; }
+
+# ---------- S5: iamf-tools via the in-tree CMakeLists ----------
+stage "S5 iamf-tools (CMake)"
+cmake -S "$REPO" -B "$SRC/build-iamf" -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$DEPS" -DIAMF_CMAKE_DEPS_ROOT="$SRC" > "$LOG/port-cfg.log" 2>&1 || { echo "PORT CFG FAIL (see $LOG/port-cfg.log)"; exit 1; }
+cmake --build "$SRC/build-iamf" -j"$JOBS" > "$LOG/port-build.log" 2>&1 || { echo "PORT BUILD FAIL (see $LOG/port-build.log)"; exit 1; }
+
+ok=1
+for t in encoder_main decoder_main probe_main; do
+  if [ -x "$SRC/build-iamf/$t" ]; then echo "built: $SRC/build-iamf/$t"; else echo "MISSING: $t"; ok=0; fi
+done
+if [ "$ok" = 1 ]; then
+  echo "=== DONE: encoder_main / decoder_main / probe_main in $SRC/build-iamf ==="
+else
+  exit 1
+fi


### PR DESCRIPTION

Follows up on #75 (and the prior art in #12 / #16): an **optional, non-default**
CMake build path for the `encoder_main` / `decoder_main` / `probe_main` CLIs,
for environments where the Bazel toolchain cannot run — networks that allow
`git clone` but block the Bazel Central Registry and release-archive fetches.
Bazel remains the build system of record; nothing about the Bazel build is
touched.

### What the PR adds — three new files, no existing file modified

- **`CMakeLists.txt`** (top level, per the guidance in #75) — written from
  scratch against the Bazel BUILD graph; no Bazel-generated content is used or
  derived. Builds an `iamf_core` static library plus the three CLIs.
- **`build_cmake.sh`** — the driver: clones the dependencies **at MODULE.bazel's
  exact pins** (abseil `20260107.1`, protobuf `v33.5`, FDK-AAC `ee76460e`,
  loudness_ebur128 `e9e73147`, obr `478dc7c7`, audio-to-tactile `d3f449fd`;
  pffft via the marton78 GitHub mirror at a fixed commit, since the restricted
  environments this path serves typically reach github.com only — the deviation
  is documented in the script header), satisfies opus/flac/expat/eigen from
  Ubuntu system packages via header shims, builds abseil → protobuf →
  iamf-tools, and ends by reconciling intent against outcome (each CLI present
  and executable; non-zero exit otherwise). Pinning everything keeps the CI job
  hermetic: a push to a dependency repo cannot change what this path builds.
- **`.github/workflows/cmake.yml`** — the CI job requested in #75, and the
  answer to #12's maintenance concern: one `ubuntu-latest` leg that builds the
  three CLIs from a clean checkout and then **exercises them** — probes two
  in-tree test files, decodes an in-tree 5.1 Opus file, and runs a full
  encode → probe → decode round-trip on in-tree vector `test_000002`. If a
  future change breaks the CMake path, this goes red visibly instead of
  failing silently for downstream users.

### Platform scope, stated plainly

This path is **Linux-only today** (same posture as #75): the CI leg is
`ubuntu-latest`, and I make no macOS/Windows claims for it. The Bazel build's
platform matrix is unaffected. Toolchain verified: GCC 13 / CMake 3.28; the
declared CMake floor (3.22) is configure- and build-tested with CMake 3.22.6.

### Verification

- Builds current `main` (`dd03679`) **unmodified** — all three CLIs produced.
- The shipped `build_cmake.sh` was run **end-to-end from a clean checkout on a
  clean environment** (fresh dependency clones at the pins, no pre-built
  state); its own reconciliation passed, and the CI workflow has a green
  hosted run on this branch.
- Functional, not just linkable: `probe_main` fully parses in-tree test files
  and an external 7.1.4 Opus sequence (complete descriptor read, `pre_skip`
  312); `decoder_main` renders in-tree files; the encode → probe → decode
  round-trip passes with the encoder reporting "Test case expected to pass".
- **Differential vs the Bazel build** (`-c opt`), same runner and checkout,
  over all 5 in-tree `.iamf` test files:
  - `probe_main` output **content-identical on every file** (4/5
    byte-identical; the fifth differs only in element print order, which the
    probe emits nondeterministically per process from hash-map iteration —
    verified by running a single binary repeatedly);
  - `decoder_main` PCM **byte-identical** on the FLAC file; the three Opus
    decodes agree within **−121 dBFS worst-case** (cross-build libopus
    float-decode variance, system 1.4 vs the source pin — far below audible
    or measurable significance at 32-bit output);
  - the encoder round-trip on `test_000002` produced **byte-identical
    bitstreams from both builds**, and their decodes are byte-identical;
  - the one in-tree LPCM file is **rejected identically by both builds** (its
    Codec Config encodes `num_samples_per_frame=0`, which current validation
    rejects).
- Two incidental findings from that differential — the `num_samples_per_frame=0`
  fixture that `docs/iamf_decoder_main.md` cites as its decode example, and the
  per-process element ordering in probe output — I would be happy to file (or
  fix) separately if useful.
- Lint: `shellcheck` clean on `build_cmake.sh`; `actionlint` clean on the
  workflow.
- The same port previously built `a7b5f4b` unmodified (noted in #75). The
  standalone interim repo
  ([jlivingston-Cipher/cmake-iamf-tools](https://github.com/jlivingston-Cipher/cmake-iamf-tools))
  carries the same build; on merge I will point it here and thin or archive it.

### Maintenance posture

Self-contained: deleting the three files removes the path entirely. I watch
this path, will keep the dependency pins moving with MODULE.bazel, and am
happy to be pinged on any breakage. If you would rather have the CI logic as a
composite action under `.github/actions/` to match the existing jobs, or a
short pointer added to `docs/build_instructions.md`, I will amend.

Contributor agreement: executed (AOMedia contributor agreement, per
CONTRIBUTING), on file since 2026-07-27.
~~~~~
Three new files, nothing modified: a top-level CMakeLists.txt (written from scratch against the Bazel BUILD graph; no Bazel-generated content is used or derived), a build_cmake.sh driver that satisfies the dependencies from git clones and system packages at the MODULE.bazel pins, and a single-leg Linux CI job that builds the three CLIs from a clean checkout and exercises them: probe, decode, and a full encode -> probe -> decode round-trip on in-tree test data.

Implements the conditions discussed in #75 (CI job included in the PR; top-level file). Prior art: #12, #16. Bazel remains the build system of record; the Bazel build is untouched.