### PR TITLE
Reconcile spliced sample counts in signed space; absorb one-sample rounding drift (fixes #68, #39)

### DIFF
--- a/iamf/cli/adm_to_user_metadata/adm/tests/BUILD
+++ b/iamf/cli/adm_to_user_metadata/adm/tests/BUILD
@@ -17,10 +17,12 @@ cc_test(
     srcs = ["wav_file_splicer_test.cc"],
     deps = [
         "//iamf/cli/adm_to_user_metadata/adm:bw64_reader",
+        "//iamf/cli/adm_to_user_metadata/adm:panner",
         "//iamf/cli/adm_to_user_metadata/adm:wav_file_splicer",
         "//iamf/cli/tests:cli_test_utils",
         "//iamf/obu:ia_sequence_header",
         "@abseil-cpp//absl/status:status_matchers",
+        "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:string_view",
         "@googletest//:gtest_main",
     ],

--- a/iamf/cli/adm_to_user_metadata/adm/tests/wav_file_splicer_test.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/tests/wav_file_splicer_test.cc
@@ -19,10 +19,12 @@
 #include <vector>
 
 #include "absl/status/status_matchers.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "iamf/cli/adm_to_user_metadata/adm/bw64_reader.h"
+#include "iamf/cli/adm_to_user_metadata/adm/panner.h"
 #include "iamf/cli/tests/cli_test_utils.h"
 #include "iamf/obu/ia_sequence_header.h"
 
@@ -288,6 +290,100 @@ TEST(SpliceWavFilesFromAdm, OutputsOneWavFilePerObject) {
       std::filesystem::path(directory) / ("prefix_converted2.wav"),
       kExpectedOutputForMonoObject);
 }
+
+// The 5-decimal ADM timecode quantization ("00:00:00.12510" for
+// 6005 / 48000 Hz = 0.125104166... s) makes the per-segment `floor()`-based
+// splice in the objects-to-3OA path come up one sample short of the wav
+// file's integer sample count. The sample-count reconciliation previously
+// compared the counts in unsigned arithmetic, so the one-sample shortfall
+// wrapped to ~1.8e19 and CHECK-crashed (#37, #39, #68). The splicer must
+// instead absorb the benign rounding drift and produce sample-exact output.
+TEST(SpliceWavFilesFromAdm, AbsorbsOneSampleRoundingDriftInObjectsMode) {
+  constexpr size_t kNumSamples = 6005;     // 0.125104166... s at 48 kHz.
+  constexpr size_t kBytesPerSample = 3;    // Dolby-mode ADM wavs are 24-bit.
+  constexpr size_t kNumInputChannels = 1;  // One audio object.
+  constexpr absl::string_view kDriftAxml =
+      R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<ebuCoreMain xmlns="urn:ebu:metadata-schema:ebuCore_2016"><coreMetadata><format><audioFormatExtended version="ITU-R_BS.2076-2">
+<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="drift_fixture" start="00:00:00.00000" end="00:00:00.12510"><audioContentIDRef>ACO_1001</audioContentIDRef><audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef></audioProgramme>
+<audioContent audioContentID="ACO_1001" audioContentName="All"><audioObjectIDRef>AO_1001</audioObjectIDRef></audioContent>
+<audioObject audioObjectID="AO_1001" audioObjectName="Obj1" start="00:00:00.00000" duration="00:00:00.12510"><audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef><audioTrackUIDRef>ATU_00000001</audioTrackUIDRef></audioObject>
+<audioPackFormat audioPackFormatID="AP_00031001" audioPackFormatName="Obj1" typeLabel="0003" typeDefinition="Objects"><audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef></audioPackFormat>
+<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="Obj1" typeLabel="0003" typeDefinition="Objects"><audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:00.00000" duration="00:00:00.12510"><cartesian>1</cartesian><position coordinate="X">-0.000000</position><position coordinate="Y">1.000000</position><position coordinate="Z">0.000000</position></audioBlockFormat></audioChannelFormat>
+<audioStreamFormat audioStreamFormatID="AS_00031001" audioStreamFormatName="PCM_AC_00031001" formatLabel="0001" formatDefinition="PCM"><audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef></audioStreamFormat>
+<audioTrackFormat audioTrackFormatID="AT_00031001_01" audioTrackFormatName="PCM_AC_00031001" formatLabel="0001" formatDefinition="PCM"><audioStreamFormatIDRef>AS_00031001</audioStreamFormatIDRef></audioTrackFormat>
+<audioTrackUID UID="ATU_00000001" sampleRate="48000" bitDepth="24"><audioTrackFormatIDRef>AT_00031001_01</audioTrackFormatIDRef><audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef></audioTrackUID>
+</audioFormatExtended></format></coreMetadata></ebuCoreMain>
+)xml";
+
+  // Assemble the BWF: `fmt ` (mono / 48 kHz / 24-bit), `dbmd` (presence
+  // routes the file down the Dolby objects-to-3OA path), `axml`, and a
+  // `data` chunk of exactly `kNumSamples` samples.
+  const auto chunk = [](absl::string_view fourcc, absl::string_view payload) {
+    const uint32_t size = static_cast<uint32_t>(payload.size());
+    std::string out(fourcc);
+    for (int shift : {0, 8, 16, 24}) {
+      out.push_back(static_cast<char>((size >> shift) & 0xff));
+    }
+    absl::StrAppend(&out, payload);
+    if (payload.size() % 2 == 1) out.push_back('\0');
+    return out;
+  };
+  constexpr absl::string_view kFmtPayload(
+      "\x01\x00"          // Format tag.
+      "\x01\x00"          // Number of channels.
+      "\x80\xbb\x00\x00"  // Samples per second (48000).
+      "\x80\x32\x02\x00"  // Bytes per second (144000).
+      "\x03\x00"          // Block align.
+      "\x18\x00",         // Bits per sample (24).
+      16);
+  const std::string wav_bytes = absl::StrCat(
+      "RIFF????WAVE",  // The reader does not depend on the RIFF size field.
+      chunk("fmt ", kFmtPayload),
+      chunk("dbmd", absl::string_view("\x00\x00\x00\x00", 4)),
+      chunk("axml", kDriftAxml),
+      chunk("data",
+            std::string(kNumSamples * kBytesPerSample * kNumInputChannels,
+                        '\0')));
+
+  std::istringstream ss(wav_bytes);
+  const auto reader = Bw64Reader::BuildFromStream(kImportanceThreshold, ss);
+  ASSERT_THAT(reader, IsOk());
+  const std::string directory = GetAndCreateOutputDirectory("");
+  int lfe_count = 0;
+
+  EXPECT_THAT(SpliceWavFilesFromAdm(directory, "prefix", kIamfBaseProfile,
+                                    *reader, ss, lfe_count),
+              IsOk());
+
+  // The panned 3OA output must exist and be sample-exact: `kNumSamples`
+  // samples across `kOutputWavChannels` channels, with no samples dropped to
+  // rounding.
+  const auto output_path =
+      std::filesystem::path(directory) / "prefix_converted1.wav";
+  ASSERT_TRUE(std::filesystem::exists(output_path));
+  std::vector<uint8_t> output_contents;
+  ASSERT_THAT(ReadFileToBytes(output_path, output_contents), IsOk());
+  // Walk the output's chunks to find the `data` chunk's size.
+  size_t data_chunk_size = 0;
+  for (size_t pos = 12; pos + 8 <= output_contents.size();) {
+    const absl::string_view fourcc(
+        reinterpret_cast<const char*>(&output_contents[pos]), 4);
+    const uint32_t size = static_cast<uint32_t>(output_contents[pos + 4]) |
+                          static_cast<uint32_t>(output_contents[pos + 5]) << 8 |
+                          static_cast<uint32_t>(output_contents[pos + 6])
+                              << 16 |
+                          static_cast<uint32_t>(output_contents[pos + 7]) << 24;
+    if (fourcc == "data") {
+      data_chunk_size = size;
+      break;
+    }
+    pos += 8 + size + (size % 2);
+  }
+  EXPECT_EQ(data_chunk_size,
+            kNumSamples * kBytesPerSample * kOutputWavChannels);
+}
+
 }  // namespace
 }  // namespace adm_to_user_metadata
 }  // namespace iamf_tools

--- a/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
@@ -55,6 +55,14 @@ constexpr size_t kMaxNumSamplesPerFrame = kSizeToFlush / 2;
 // Error tolerance set to the minimum precision allowed by ADM file to describe
 // timing related parameters.
 constexpr double kErrorTolerance = 1e-5;
+
+// The per-segment `floor()`-plus-carried-leftover accumulation in
+// `ConvertFromObjectsTo3OA` can land one sample short of the integer total
+// when a segment boundary falls on an exact sample but the double product
+// rounds just below it (e.g. 163.89 s * 48000 Hz =
+// 7866719.99999999906...; #37, #39, #68). Only the final fractional
+// leftover can be lost this way, so the benign drift is at most one sample.
+constexpr int64_t kMaxSpliceRoundingDriftSamples = 1;
 // Offset for data chunk within the extensible format wav file.
 constexpr int32_t kExtensibleOffset = 72;
 // Standard size for a wav header.
@@ -343,8 +351,8 @@ absl::Status ConvertFromObjectsTo3OA(
   double total_processed_duration = 0.0;
   // Holds the number of samples left over from the previous segment due to
   // rounding error.
-  double leftover_sample_duration = 0.0f;
-  int num_samples_count = 0;
+  double leftover_sample_duration = 0.0;
+  int64_t num_samples_count = 0;
 
   // Initialize segment duration for all channels with the corresponding first
   // audio block duration.
@@ -408,14 +416,20 @@ absl::Status ConvertFromObjectsTo3OA(
           leftover_sample_duration;
       // Length of the processed audio segment. Samples are rounded off for the
       // current segment.
-      const auto processed_seg_length = std::floor(this_seg_length);
-      leftover_sample_duration = this_seg_length - processed_seg_length;
+      const auto processed_seg_length =
+          static_cast<int64_t>(std::floor(this_seg_length));
+      leftover_sample_duration =
+          this_seg_length - static_cast<double>(processed_seg_length);
 
       num_samples_count += processed_seg_length;
 
-      ABSL_CHECK_LE(processed_seg_length, *total_samples_per_channel)
-          << "Samples in segment should not be greater than actual samples in "
-             "the wav file";
+      if (processed_seg_length >
+          static_cast<int64_t>(*total_samples_per_channel)) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Segment length (", processed_seg_length,
+            ") should not be greater than the actual samples per channel (",
+            *total_samples_per_channel, ") in the wav file."));
+      }
 
       RETURN_IF_NOT_OK(SpliceWavSegment(input_stream, processed_seg_length,
                                         total_channel_size, samples_buffer,
@@ -431,10 +445,41 @@ absl::Status ConvertFromObjectsTo3OA(
                             audio_block_indices);
   }
 
-  ABSL_CHECK_LE(fabs(total_processed_duration - total_duration),
-                kErrorTolerance);
-  ABSL_CHECK_LE(fabs(num_samples_count - *total_samples_per_channel),
-                kErrorTolerance);
+  if (fabs(total_processed_duration - total_duration) > kErrorTolerance) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Total processed duration (", total_processed_duration,
+                     ") does not reconcile with the wav file duration (",
+                     total_duration, ")."));
+  }
+  // Reconcile the spliced sample count in signed integer space. The previous
+  // unsigned comparison wrapped a one-sample shortfall to ~1.8e19 and
+  // CHECK-crashed. A shortfall within `kMaxSpliceRoundingDriftSamples` is
+  // benign floating-point rounding: the unread remainder is still in
+  // `input_stream`, so splice it through the panner (with the final block
+  // metadata) to keep the output sample-exact.
+  const int64_t sample_count_drift =
+      static_cast<int64_t>(*total_samples_per_channel) - num_samples_count;
+  if (sample_count_drift < 0 ||
+      sample_count_drift > kMaxSpliceRoundingDriftSamples) {
+    return absl::InternalError(absl::StrCat(
+        "Spliced sample count (", num_samples_count,
+        ") does not reconcile with the samples per channel in the wav file (",
+        *total_samples_per_channel, ")."));
+  }
+  if (sample_count_drift > 0) {
+    {
+      auto wav_writer = WavWriter::Create(
+          input_file.string(), wav_file_fmt.num_channels,
+          wav_file_fmt.samples_per_sec, wav_file_fmt.bits_per_sample,
+          kMaxNumSamplesPerFrame);
+      RETURN_IF_NOT_OK(SpliceWavSegment(input_stream, sample_count_drift,
+                                        total_channel_size, samples_buffer,
+                                        *wav_writer));
+    }
+    RETURN_IF_NOT_OK(PanObjectsToAmbisonics(input_file.string(), input_adm,
+                                            audio_block_indices,
+                                            *output_wav_writer));
+  }
 
   // Delete the temporary files.
   if (!std::filesystem::remove(input_file)) {


### PR DESCRIPTION
Follows up on #75's invitation to send fixes for the recently filed issues.

## Root cause

As analyzed in #68 and independently measured in #39: the objects-to-3OA
splice (`wav_file_splicer.cc`) computes per-segment sample counts by
`floor()`-ing double products of parsed ADM durations. When a segment
boundary falls on an exact sample but the double product rounds just below
it (e.g. 163.89 s × 48000 Hz = 7866719.99999999906…), the splice comes up
one sample short. The final reconciliation —
`fabs(num_samples_count - *total_samples_per_channel)` — then promotes the
`int` count through unsigned arithmetic, so the −1 shortfall wraps to
~1.84467e+19 and the `CHECK` aborts (SIGABRT). Whether a given input trips
this depends only on which way the products round, which is why roughly
half of plausible authoring grids crash (boundary table in #68).

fecb716 moved the *total* sample count into integer space; the
*per-segment* products and the final reconciliation still ran through
doubles and unsigned promotion. This PR completes that arc:

- Reconcile in signed 64-bit space and return a `Status` instead of
  crashing.
- Absorb a one-sample shortfall by splicing the still-unread remainder
  through the panner, so the output stays sample-exact (no padding, the
  real final sample).
- Convert the per-segment and total-duration `CHECK`s on input-dependent
  values to `Status`es (an encoder should not abort on valid input).
- Add a regression test — the first to exercise the Dolby objects-to-3OA
  path: a 6005-sample mono ADM BWF (`00:00:00.12510` at 48 kHz, i.e. the
  5-decimal ADM timecode quantization of 0.125104166… s) that previously
  crashed with #39's exact signature and must now produce sample-exact 3OA
  output.

What this deliberately does **not** do: re-time the segmentation.
Per-segment lengths are computed exactly as before, so output for inputs
that already worked is unchanged (verified below).

## Verification (Linux, at dd03679)

- #68's repro reproduces pre-fix at `dd03679` (SIGABRT,
  `wav_file_splicer.cc:436`, magnitude 1.84467e+19) and completes cleanly
  post-fix (exit 0, valid `.iamf`).
- No-regression control: two automation grids that already passed
  (200-block and 1000-block, from the generator cited in #68) produce
  **byte-identical** `.iamf` output pre/post fix.
- The new test fails on the unfixed code (dies on the same `CHECK`) and
  passes with the fix, asserting the panned output is exactly
  6005 × 16 ch × 3 B.
- `bazelisk test -c opt --test_output=errors iamf/...` (the repo's CI
  suite) is green on this branch across the full matrix — linux-amd64,
  macos-arm64, macos-amd64, windows, plus the test-vector generator
  (fork Actions run
  [30877230150](https://github.com/jlivingston-Cipher/iamf-tools/actions/runs/30877230150));
  `//iamf/cli/adm_to_user_metadata/adm/tests:wav_file_splicer_test`
  PASSED.
- `git-clang-format dd03679` is idempotent on the change.

On #37: fecb716 addressed that report's total-samples computation; this
change converts the remaining aborts in the same function to clean errors.

Contributor agreement: executed and on file since 2026-07-27 (per
CONTRIBUTING), as with #78.
