### PR TITLE
Make the CMake build path work on macOS (follow-up to #78)

### DIFF
--- a/.github/actions/iamf-tools-cmake-builder/action.yml
+++ b/.github/actions/iamf-tools-cmake-builder/action.yml
@@ -1,0 +1,53 @@
+name: iamf-tools-cmake-builder
+
+description: Build the IAMF Tools CLIs via the optional CMake path and smoke-test them.
+
+inputs:
+  platform:
+    description: "The platform to build for."
+    type: string
+    default: linux
+
+runs:
+  using: composite
+  steps:
+    - name: Install system packages
+      shell: bash
+      run: |
+        if [[ "${{inputs.platform}}" == "macos" ]]; then
+          # expat comes from the Xcode Command Line Tools SDK; macOS has no
+          # /usr/include, so build_cmake.sh discovers each header (see S2 there).
+          brew install cmake opus flac eigen
+        else
+          sudo apt-get update
+          sudo apt-get install -y cmake pkg-config g++ \
+            libopus-dev libflac-dev libexpat1-dev libeigen3-dev
+        fi
+    - name: Build (CMake path)
+      shell: bash
+      run: ./build_cmake.sh "$RUNNER_TEMP/cmake-build"
+    - name: Smoke test (probe, decode, encode round-trip on in-tree data)
+      shell: bash
+      run: |
+        set -eux
+        BIN="$RUNNER_TEMP/cmake-build/src/build-iamf"
+        # Probe: parse descriptors of two in-tree IAMF files.
+        "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf
+        "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/tones_100ms_3OA_stereo_opus.iamf
+        # Decode: render an in-tree 5.1 Opus file; output must be non-empty.
+        "$BIN/decoder_main" \
+          --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf \
+          --output_filename="$RUNNER_TEMP/smoke_dec.wav"
+        test -s "$RUNNER_TEMP/smoke_dec.wav"
+        # Encode round-trip: encode an in-tree test vector, then probe and
+        # decode the result with the same freshly built tools.
+        mkdir -p "$RUNNER_TEMP/smoke_enc"
+        "$BIN/encoder_main" \
+          --user_metadata_filename=iamf/cli/testdata/test_000002.textproto \
+          --input_wav_directory=iamf/cli/testdata \
+          --output_iamf_directory="$RUNNER_TEMP/smoke_enc"
+        "$BIN/probe_main" --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf"
+        "$BIN/decoder_main" \
+          --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf" \
+          --output_filename="$RUNNER_TEMP/smoke_enc_dec.wav"
+        test -s "$RUNNER_TEMP/smoke_enc_dec.wav"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,11 @@
 name: cmake
 
 # Keeps the optional CMake build path (iamf-tools#75) honest: builds the three
-# CLIs from a clean checkout on Linux, then exercises them — probe, decode, and
-# a full encode -> probe -> decode round-trip — on in-tree test data. This
-# workflow is self-contained: removing it (plus CMakeLists.txt and
-# build_cmake.sh) removes the CMake path entirely.
+# CLIs from a clean checkout, then exercises them — probe, decode, and a full
+# encode -> probe -> decode round-trip — on in-tree test data. The per-platform
+# steps live in .github/actions/iamf-tools-cmake-builder, so adding an OS is a
+# job block. This workflow is self-contained: removing it (plus that action,
+# CMakeLists.txt and build_cmake.sh) removes the CMake path entirely.
 
 on: [push, pull_request]
 
@@ -18,71 +19,17 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake pkg-config g++ \
-            libopus-dev libflac-dev libexpat1-dev libeigen3-dev
-      - name: Build (CMake path)
-        run: ./build_cmake.sh "$RUNNER_TEMP/cmake-build"
-      - name: Smoke test (probe, decode, encode round-trip on in-tree data)
-        run: |
-          set -eux
-          BIN="$RUNNER_TEMP/cmake-build/src/build-iamf"
-          # Probe: parse descriptors of two in-tree IAMF files.
-          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf
-          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/tones_100ms_3OA_stereo_opus.iamf
-          # Decode: render an in-tree 5.1 Opus file; output must be non-empty.
-          "$BIN/decoder_main" \
-            --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf \
-            --output_filename="$RUNNER_TEMP/smoke_dec.wav"
-          test -s "$RUNNER_TEMP/smoke_dec.wav"
-          # Encode round-trip: encode an in-tree test vector, then probe and
-          # decode the result with the same freshly built tools.
-          mkdir -p "$RUNNER_TEMP/smoke_enc"
-          "$BIN/encoder_main" \
-            --user_metadata_filename=iamf/cli/testdata/test_000002.textproto \
-            --input_wav_directory=iamf/cli/testdata \
-            --output_iamf_directory="$RUNNER_TEMP/smoke_enc"
-          "$BIN/probe_main" --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf"
-          "$BIN/decoder_main" \
-            --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf" \
-            --output_filename="$RUNNER_TEMP/smoke_enc_dec.wav"
-          test -s "$RUNNER_TEMP/smoke_enc_dec.wav"
-
+      - name: Build and smoke test
+        uses: ./.github/actions/iamf-tools-cmake-builder
+        with:
+          platform: linux
   macos-arm64-cmake:
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
-      - name: Install system packages
-        # expat comes from the Xcode Command Line Tools SDK; macOS has no
-        # /usr/include, so build_cmake.sh discovers each header (see S2 there).
-        run: brew install cmake opus flac eigen
-      - name: Build (CMake path)
-        run: ./build_cmake.sh "$RUNNER_TEMP/cmake-build"
-      - name: Smoke test (probe, decode, encode round-trip on in-tree data)
-        run: |
-          set -eux
-          BIN="$RUNNER_TEMP/cmake-build/src/build-iamf"
-          # Probe: parse descriptors of two in-tree IAMF files.
-          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf
-          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/tones_100ms_3OA_stereo_opus.iamf
-          # Decode: render an in-tree 5.1 Opus file; output must be non-empty.
-          "$BIN/decoder_main" \
-            --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf \
-            --output_filename="$RUNNER_TEMP/smoke_dec.wav"
-          test -s "$RUNNER_TEMP/smoke_dec.wav"
-          # Encode round-trip: encode an in-tree test vector, then probe and
-          # decode the result with the same freshly built tools.
-          mkdir -p "$RUNNER_TEMP/smoke_enc"
-          "$BIN/encoder_main" \
-            --user_metadata_filename=iamf/cli/testdata/test_000002.textproto \
-            --input_wav_directory=iamf/cli/testdata \
-            --output_iamf_directory="$RUNNER_TEMP/smoke_enc"
-          "$BIN/probe_main" --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf"
-          "$BIN/decoder_main" \
-            --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf" \
-            --output_filename="$RUNNER_TEMP/smoke_enc_dec.wav"
-          test -s "$RUNNER_TEMP/smoke_enc_dec.wav"
+      - name: Build and smoke test
+        uses: ./.github/actions/iamf-tools-cmake-builder
+        with:
+          platform: macos

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,3 +49,40 @@ jobs:
             --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf" \
             --output_filename="$RUNNER_TEMP/smoke_enc_dec.wav"
           test -s "$RUNNER_TEMP/smoke_enc_dec.wav"
+
+  macos-arm64-cmake:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Install system packages
+        # expat comes from the Xcode Command Line Tools SDK; macOS has no
+        # /usr/include, so build_cmake.sh discovers each header (see S2 there).
+        run: brew install cmake opus flac eigen
+      - name: Build (CMake path)
+        run: ./build_cmake.sh "$RUNNER_TEMP/cmake-build"
+      - name: Smoke test (probe, decode, encode round-trip on in-tree data)
+        run: |
+          set -eux
+          BIN="$RUNNER_TEMP/cmake-build/src/build-iamf"
+          # Probe: parse descriptors of two in-tree IAMF files.
+          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf
+          "$BIN/probe_main" --input_filename=iamf/cli/testdata/iamf/tones_100ms_3OA_stereo_opus.iamf
+          # Decode: render an in-tree 5.1 Opus file; output must be non-empty.
+          "$BIN/decoder_main" \
+            --input_filename=iamf/cli/testdata/iamf/noise_1024samp_5p1_opus.iamf \
+            --output_filename="$RUNNER_TEMP/smoke_dec.wav"
+          test -s "$RUNNER_TEMP/smoke_dec.wav"
+          # Encode round-trip: encode an in-tree test vector, then probe and
+          # decode the result with the same freshly built tools.
+          mkdir -p "$RUNNER_TEMP/smoke_enc"
+          "$BIN/encoder_main" \
+            --user_metadata_filename=iamf/cli/testdata/test_000002.textproto \
+            --input_wav_directory=iamf/cli/testdata \
+            --output_iamf_directory="$RUNNER_TEMP/smoke_enc"
+          "$BIN/probe_main" --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf"
+          "$BIN/decoder_main" \
+            --input_filename="$RUNNER_TEMP/smoke_enc/test_000002.iamf" \
+            --output_filename="$RUNNER_TEMP/smoke_enc_dec.wav"
+          test -s "$RUNNER_TEMP/smoke_enc_dec.wav"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ find_library(OPUS_LIB opus REQUIRED)
 find_library(FLAC_LIB FLAC REQUIRED)
 find_library(EXPAT_LIB expat REQUIRED)
 
+# Eigen is header-only and ships under an `eigen3/` suffix on every distro, but
+# the prefix is not portable: Debian/Ubuntu use /usr/include/eigen3, Homebrew
+# uses ${brew_prefix}/include/eigen3, and macOS has no /usr/include at all.
+# Discover it rather than hardcoding one distro's layout.
+find_path(EIGEN_INC NAMES Eigen/Core PATH_SUFFIXES eigen3 REQUIRED)
+
 # ---------------- FDK-AAC (exact upstream pin, own CMake) -------------------
 # Non-recursive on purpose: lib*/src/{arm,mips,x86}/ hold #include-only
 # assembly specializations that do not compile standalone.
@@ -71,7 +77,7 @@ target_link_libraries(ebur128_analyzer PUBLIC absl::status absl::statusor
 file(GLOB_RECURSE OBR_SRCS ${SRC}/obr/obr/*.cc)
 list(FILTER OBR_SRCS EXCLUDE REGEX "/tests?/|_test\\.cc|test_util\\.cc|/cli/")
 add_library(obr_lib STATIC ${OBR_SRCS})
-target_include_directories(obr_lib PUBLIC ${SRC}/obr /usr/include/eigen3)
+target_include_directories(obr_lib PUBLIC ${SRC}/obr ${EIGEN_INC})
 target_link_libraries(obr_lib PUBLIC pffft_static a2t_dsp
     absl::log absl::check absl::status absl::statusor absl::strings
     absl::flat_hash_map absl::span)
@@ -107,7 +113,7 @@ target_include_directories(iamf_core PUBLIC
     ${SRC}/shims/flac            # "include/FLAC/..."
     ${SRC}/shims/opus            # "include/opus.h"
     ${SRC}/shims/expat           # "expat/lib/expat.h"
-    /usr/include/eigen3)
+    ${EIGEN_INC})
 target_link_libraries(iamf_core PUBLIC
     iamf_protos ebur128_analyzer obr_lib a2t_dsp fdk_aac_static
     ${OPUS_LIB} ${FLAC_LIB} ${EXPAT_LIB}

--- a/build_cmake.sh
+++ b/build_cmake.sh
@@ -21,6 +21,10 @@
 #                             # nothing under iamf/ is written)
 # Requirements (Debian/Ubuntu names): cmake pkg-config git g++
 #   libopus-dev libflac-dev libexpat1-dev libeigen3-dev
+# Requirements (macOS / Homebrew):     brew install cmake pkg-config opus flac eigen
+#   expat is supplied by the Xcode Command Line Tools SDK. macOS has no
+#   /usr/include at all, so system headers are discovered (S2 below) and eigen
+#   is located with find_path rather than a fixed prefix.
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")" && pwd)"
@@ -28,7 +32,7 @@ ROOT="${1:-$(pwd)/build}"
 SRC="$ROOT/src"
 DEPS="$ROOT/deps"
 LOG="$ROOT/logs"
-JOBS="${JOBS:-$(nproc 2>/dev/null || echo 2)}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)}"
 mkdir -p "$SRC" "$DEPS" "$LOG"
 
 stage() { echo "=== $1 [$(date +%H:%M:%S)] ==="; }
@@ -78,12 +82,34 @@ clone pffft            https://github.com/marton78/pffft           a4b03590cc2a4
 
 # ---------- S2: header shims for Bazel-style repo-relative includes ----------
 stage "S2 shims"
+# System header prefixes are not portable: Debian/Ubuntu use /usr/include,
+# Homebrew uses $(brew --prefix)/include, and macOS has no /usr/include at all
+# (expat ships inside the Xcode Command Line Tools SDK). Discover each header
+# instead of hardcoding one distro's layout.
+HDR_PREFIXES="/usr/include"
+_brew="$(brew --prefix 2>/dev/null || true)"
+[ -n "$_brew" ] && HDR_PREFIXES="$HDR_PREFIXES $_brew/include"
+_sdk="$(xcrun --show-sdk-path 2>/dev/null || true)"
+[ -n "$_sdk" ] && HDR_PREFIXES="$HDR_PREFIXES $_sdk/usr/include"
+find_hdr() { for p in $HDR_PREFIXES; do [ -e "$p/$1" ] && { printf '%s\n' "$p/$1"; return 0; }; done; return 1; }
+
 mkdir -p "$SRC/shims/flac/include" "$SRC/shims/opus/include" "$SRC/shims/expat/expat/lib"
-ln -sf /usr/include/FLAC "$SRC/shims/flac/include/FLAC"
-for h in /usr/include/opus/*.h; do ln -sf "$h" "$SRC/shims/opus/include/"; done
-ln -sf /usr/include/expat.h          "$SRC/shims/expat/expat/lib/expat.h"
-ln -sf /usr/include/expat_external.h "$SRC/shims/expat/expat/lib/expat_external.h"
-ln -sf /usr/include/expat_config.h   "$SRC/shims/expat/expat/lib/expat_config.h" 2>/dev/null || true
+FLAC_H="$(find_hdr FLAC)"     || { echo "S2 FAIL: FLAC headers not found in: $HDR_PREFIXES" >&2; exit 1; }
+OPUS_H="$(find_hdr opus)"     || { echo "S2 FAIL: opus headers not found in: $HDR_PREFIXES" >&2; exit 1; }
+EXPAT_H="$(find_hdr expat.h)" || { echo "S2 FAIL: expat.h not found in: $HDR_PREFIXES" >&2; exit 1; }
+ln -sf "$FLAC_H" "$SRC/shims/flac/include/FLAC"
+for h in "$OPUS_H"/*.h; do ln -sf "$h" "$SRC/shims/opus/include/"; done
+ln -sf "$EXPAT_H" "$SRC/shims/expat/expat/lib/expat.h"
+for extra in expat_external.h expat_config.h; do
+  _e="$(find_hdr "$extra")" && ln -sf "$_e" "$SRC/shims/expat/expat/lib/$extra"
+done
+# `ln -sf` to a NONEXISTENT target succeeds and returns 0, so without this check
+# the shim stage cannot fail on a missing dependency -- the error instead surfaces
+# hundreds of lines later as a confusing missing-header compile failure.
+for l in "$SRC/shims/flac/include/FLAC" "$SRC/shims/expat/expat/lib/expat.h"; do
+  [ -e "$l" ] || { echo "S2 FAIL: dangling shim symlink $l -> $(readlink "$l")" >&2; exit 1; }
+done
+echo "S2 shims OK: FLAC=$FLAC_H opus=$OPUS_H expat=$EXPAT_H"
 
 # ---------- S3: abseil (static, C++20, propagate std) ----------
 cmake_install abseil "$SRC/abseil-cpp" "$SRC/build-absl" \


### PR DESCRIPTION
Follow-up to #78, which was merged this morning — thanks for taking those changes, and for the `run_logged` / `cmake_install` cleanups. They're an improvement on what was sent, and the `clone()` rewrite is measurably faster: dependency cloning went from ~4.5 min to **11 s** on my machine. You wrote *"if they don't work for your environment feel free to discuss or file another PR"*, so here is the environment half.

**Scope: the optional CMake path only** (`build_cmake.sh` + `CMakeLists.txt`, both new in #78). This is **not** a re-opening of #7/#8 — the Bazel build on macOS was fixed in 2024 and has had a `macos-latest` leg ever since. That leg doesn't cover the CMake path, which is currently `linux-amd64-cmake` only.

`build_cmake.sh` at `81517e1` does not build on macOS. Four causes, and **three fail silently** — which is the part I think is worth your time.

## The one that matters: S2 cannot fail

`ln -sf` to a **nonexistent** target succeeds and returns 0. macOS has no `/usr/include` at all, so on a Mac the shim stage creates five dangling symlinks and reports success:

```
# S2 stage, verbatim from build_cmake.sh @ 81517e1, on macOS:
>>> exit code: 0
  DANGLING flac/include/FLAC                -> /usr/include/FLAC
  DANGLING expat/expat/lib/expat.h          -> /usr/include/expat.h
  DANGLING expat/expat/lib/expat_external.h -> /usr/include/expat_external.h
  DANGLING expat/expat/lib/expat_config.h   -> /usr/include/expat_config.h
  DANGLING opus/include/*.h                 -> /usr/include/opus/*.h
  symlinks created: 5 ; DANGLING: 5
```

Note the last one: `for h in /usr/include/opus/*.h` doesn't match, and with `nullglob` off the literal pattern passes through — so the script creates a symlink named `*.h`.

The failure then surfaces a few hundred lines later as a missing-header compile error, pointing at the wrong thing. The fix resolves each header **before** linking and re-checks the links after, so the stage fails where the problem actually is.

## The other three

| Cause                                                                                 | Effect                                                                   |
| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| `/usr/include/eigen3` hardcoded in `CMakeLists.txt` (`:74` obr_lib, `:110` iamf_core) | no such path on macOS; eigen is at `$(brew --prefix)/include/eigen3`     |
| `/usr/include` hardcoded 5× in the S2 stage                                           | as above; expat lives in the Xcode CLT SDK                               |
| `JOBS="${JOBS:-$(nproc 2>/dev/null \|\| echo 2)}"`                                    | no `nproc` on macOS ⇒ silent fallback to **2 jobs on an 8-core machine** |

## The change

`+77 / −8` across three files. It doesn't touch `run_logged`, `cmake_install`, or `clone` — your structure is preserved throughout.

- `find_path(EIGEN_INC NAMES Eigen/Core PATH_SUFFIXES eigen3 REQUIRED)` and two call sites. I used `find_path` rather than `find_package(Eigen3)` because eigen here is header-only and consumed by include path, and `find_package` needs a config package that `libeigen3-dev` doesn't install on every Debian version — **happy to switch if you'd rather have `find_package`**.
- A `find_hdr()` helper searching `/usr/include`, `$(brew --prefix)/include`, and `$(xcrun --show-sdk-path)/usr/include`, with an explicit `S2 FAIL:` + `exit 1` when a header isn't found, plus a post-link dangling check.
- `JOBS` falls back through `nproc` → `sysctl -n hw.ncpu` → `getconf _NPROCESSORS_ONLN` → 2.
- A macOS line in the requirements comment block.

### One deliberate Linux difference, and it's the only one

I ran the current and patched S2 stages side by side on Debian with `libflac-dev libopus-dev libexpat1-dev` installed and diffed the resulting shim trees. They are identical except for one link:

```
- shims/expat/expat/lib/expat_config.h -> /usr/include/expat_config.h
```

The patched version doesn't create it, because Debian ships that header at the **multiarch** path `/usr/include/x86_64-linux-gnu/expat_config.h` — so the current script's link is **dangling on Debian too**, which is what the `2>/dev/null || true` is absorbing. `linux-amd64-cmake` is green on `81517e1` with it dangling, so nothing consumes it. I've left it out rather than teach `find_hdr` about multiarch, since that would be a larger change to Linux behaviour in service of a header nothing includes. Say the word if you'd rather it resolve properly.

Everything else on Linux resolves byte-for-byte as it does today.

## Verification

Built from a clean checkout of `81517e1` + this patch on **macOS / Apple silicon / Homebrew**, into a fresh build root: **3 min 49 s**, producing working arm64 `encoder_main` (10 M), `decoder_main` (6.9 M), `probe_main` (2.0 M).

The shim stage, three ways:

|                                 | exit                                            | links | dangling |
| ------------------------------- | ----------------------------------------------- | ----- | -------- |
| `81517e1` as merged             | **0**                                           | 5     | **5**    |
| with this patch                 | 0                                               | 9     | **0**    |
| with this patch, headers hidden | **1** — `S2 FAIL: FLAC headers not found in: …` | —     | —        |

The third row is the point: the stage now fails closed, where before it could not fail at all.

I also ran a two-point known-answer check on the resulting binaries, using ADM BW64 fixtures with and without a Dolby metadata chunk, at both profile versions — all four reproduced their expected verdicts (`rc=0` + 1 `.iamf` / `rc=5` + 0 `.iamf`). So the binaries work, not merely compile.

## The CI leg

#8 was closed with *"Let's add a `macos-latest` target to the GitHub Actions CI before closing this bug"*, and in #7 it was noted that a Mac test platform was unavailable at the time. Both still apply here, so I've added a `macos-arm64-cmake` job to `cmake.yml` mirroring the Linux one — Homebrew deps instead of apt, same smoke test. Without it this patch is just my word, and the path will drift again the next time someone touches it.

I added it as a **second job rather than converting the existing one to a matrix**, deliberately: a matrix would rename `linux-amd64-cmake` to something like `cmake (ubuntu-latest)` and silently invalidate any branch-protection rule referencing the old name. That costs some duplication in the smoke-test block — happy to switch to a matrix if you'd prefer it and the rename is safe on your side.

If you'd rather keep `cmake.yml` single-platform, say so and I'll drop that file — the portability fixes should stand on their own.
