### PR TITLE
adm_to_user_metadata: read spherical audioBlockFormat positions

### DIFF
--- a/iamf/cli/adm_to_user_metadata/adm/adm_elements.h
+++ b/iamf/cli/adm_to_user_metadata/adm/adm_elements.h
@@ -108,9 +108,20 @@ struct AudioPackFormat {
 
 // This structure holds cartesian position associated with an audio block.
 struct CartesianPosition {
-  float x;
-  float y;
-  float z;
+  float x = 0.0f;
+  float y = 0.0f;
+  float z = 0.0f;
+};
+
+// This structure holds a spherical position as authored in BS.2076
+// (`azimuth`/`elevation`/`distance`). Blocks may be authored in either
+// convention; this is retained so the cartesian `position` can be derived from
+// it, and so a partially specified spherical position keeps the BS.2076
+// defaults for the coordinates that were omitted.
+struct SphericalPosition {
+  float azimuth = 0.0f;
+  float elevation = 0.0f;
+  float distance = 1.0f;
 };
 
 struct BlockTime {
@@ -128,6 +139,11 @@ struct AudioBlockFormat {
   BlockTime duration;
   float gain = kDefaultBlockGain;
   CartesianPosition position;
+  // Set when any of `azimuth`, `elevation` or `distance` was parsed for this
+  // block. `position` is then derived from `spherical_position` rather than
+  // read directly from `coordinate="X"/"Y"/"Z"`.
+  bool has_spherical_position = false;
+  SphericalPosition spherical_position;
 };
 
 // This structure holds the attributes of an audio channel format in ADM.

--- a/iamf/cli/adm_to_user_metadata/adm/tests/xml_to_adm_test.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/tests/xml_to_adm_test.cc
@@ -32,6 +32,7 @@ using testing::ElementsAreArray;
 constexpr absl::string_view kAudioPackFormatIdMono = "AP_00010001";
 
 constexpr int kImportanceThreshold = 0;
+constexpr float kPositionTolerance = 1e-5f;
 
 TEST(ParseXmlToAdm, InvalidXml) {
   EXPECT_THAT(ParseXmlToAdm(R"xml(<open_tag> </mismatching_close_tag>)xml",
@@ -78,6 +79,151 @@ TEST(ParseXmlToAdm, AudioBlockFormatWithoutParentChannelIsRejected) {
                   </audioBlockFormat>
                 </audioFormatExtended>)xml",
                             kImportanceThreshold, kAdmFileTypeDefault),
+              Not(IsOk()));
+}
+
+TEST(ParseXmlToAdm, LoadsCartesianBlockPosition) {
+  const auto adm = ParseXmlToAdm(
+      R"xml(
+        <audioChannelFormat audioChannelFormatID="AC_00031001">
+          <audioBlockFormat audioBlockFormatID="AB_00031001_00000001">
+            <position coordinate="X">-1.0</position>
+            <position coordinate="Y">0.0</position>
+            <position coordinate="Z">0.0</position>
+          </audioBlockFormat>
+        </audioChannelFormat>
+  )xml",
+      kImportanceThreshold, kAdmFileTypeDefault);
+  ASSERT_THAT(adm, IsOk());
+  ASSERT_FALSE(adm->audio_channels.empty());
+  ASSERT_FALSE(adm->audio_channels[0].audio_blocks.empty());
+
+  const auto& block = adm->audio_channels[0].audio_blocks[0];
+  EXPECT_FALSE(block.has_spherical_position);
+  EXPECT_NEAR(block.position.x, -1.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.y, 0.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.z, 0.0f, kPositionTolerance);
+}
+
+TEST(ParseXmlToAdm, BlockPositionDefaultsToTheOriginWhenAbsent) {
+  // A block with no readable position must be a determinate origin rather than
+  // whatever `CartesianPosition`'s members happened to contain.
+  const auto adm = ParseXmlToAdm(
+      R"xml(
+        <audioChannelFormat audioChannelFormatID="AC_00031001">
+          <audioBlockFormat audioBlockFormatID="AB_00031001_00000001">
+            <speakerLabel>M+030</speakerLabel>
+          </audioBlockFormat>
+        </audioChannelFormat>
+  )xml",
+      kImportanceThreshold, kAdmFileTypeDefault);
+  ASSERT_THAT(adm, IsOk());
+  ASSERT_FALSE(adm->audio_channels.empty());
+  ASSERT_FALSE(adm->audio_channels[0].audio_blocks.empty());
+
+  const auto& block = adm->audio_channels[0].audio_blocks[0];
+  EXPECT_EQ(block.position.x, 0.0f);
+  EXPECT_EQ(block.position.y, 0.0f);
+  EXPECT_EQ(block.position.z, 0.0f);
+}
+
+TEST(ParseXmlToAdm, LoadsSphericalBlockPositionAsCartesian) {
+  // `azimuth`/`elevation`/`distance` is equally valid BS.2076 and is what the
+  // EAR/BBC tooling emits by default. Azimuth is measured anticlockwise from
+  // front, so azimuth 90 is the listener's left: (-1, 0, 0).
+  const auto adm = ParseXmlToAdm(
+      R"xml(
+        <audioChannelFormat audioChannelFormatID="AC_00031001">
+          <audioBlockFormat audioBlockFormatID="AB_00031001_00000001">
+            <position coordinate="azimuth">90.0</position>
+            <position coordinate="elevation">0.0</position>
+            <position coordinate="distance">1.0</position>
+          </audioBlockFormat>
+        </audioChannelFormat>
+  )xml",
+      kImportanceThreshold, kAdmFileTypeDefault);
+  ASSERT_THAT(adm, IsOk());
+  ASSERT_FALSE(adm->audio_channels.empty());
+  ASSERT_FALSE(adm->audio_channels[0].audio_blocks.empty());
+
+  const auto& block = adm->audio_channels[0].audio_blocks[0];
+  EXPECT_TRUE(block.has_spherical_position);
+  EXPECT_NEAR(block.position.x, -1.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.y, 0.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.z, 0.0f, kPositionTolerance);
+}
+
+TEST(ParseXmlToAdm, SphericalBlockPositionAtTheFrontMatchesItsCartesianTwin) {
+  // azimuth 0 / elevation 0 / distance 1 is the same point as (0, 1, 0).
+  const auto adm = ParseXmlToAdm(
+      R"xml(
+        <audioChannelFormat audioChannelFormatID="AC_00031001">
+          <audioBlockFormat audioBlockFormatID="AB_00031001_00000001">
+            <position coordinate="azimuth">0.0</position>
+            <position coordinate="elevation">0.0</position>
+            <position coordinate="distance">1.0</position>
+          </audioBlockFormat>
+        </audioChannelFormat>
+  )xml",
+      kImportanceThreshold, kAdmFileTypeDefault);
+  ASSERT_THAT(adm, IsOk());
+
+  const auto& block = adm->audio_channels[0].audio_blocks[0];
+  EXPECT_NEAR(block.position.x, 0.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.y, 1.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.z, 0.0f, kPositionTolerance);
+}
+
+TEST(ParseXmlToAdm, SphericalBlockPositionHonoursElevationAndDistance) {
+  const auto adm = ParseXmlToAdm(
+      R"xml(
+        <audioChannelFormat audioChannelFormatID="AC_00031001">
+          <audioBlockFormat audioBlockFormatID="AB_00031001_00000001">
+            <position coordinate="azimuth">0.0</position>
+            <position coordinate="elevation">90.0</position>
+            <position coordinate="distance">2.0</position>
+          </audioBlockFormat>
+        </audioChannelFormat>
+  )xml",
+      kImportanceThreshold, kAdmFileTypeDefault);
+  ASSERT_THAT(adm, IsOk());
+
+  const auto& block = adm->audio_channels[0].audio_blocks[0];
+  EXPECT_NEAR(block.position.x, 0.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.y, 0.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.z, 2.0f, kPositionTolerance);
+}
+
+TEST(ParseXmlToAdm,
+     SphericalBlockPositionUsesBs2076DefaultsForOmittedCoordinates) {
+  // Only azimuth is authored; distance defaults to 1 and elevation to 0.
+  const auto adm = ParseXmlToAdm(
+      R"xml(
+        <audioChannelFormat audioChannelFormatID="AC_00031001">
+          <audioBlockFormat audioBlockFormatID="AB_00031001_00000001">
+            <position coordinate="azimuth">-90.0</position>
+          </audioBlockFormat>
+        </audioChannelFormat>
+  )xml",
+      kImportanceThreshold, kAdmFileTypeDefault);
+  ASSERT_THAT(adm, IsOk());
+
+  const auto& block = adm->audio_channels[0].audio_blocks[0];
+  EXPECT_NEAR(block.position.x, 1.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.y, 0.0f, kPositionTolerance);
+  EXPECT_NEAR(block.position.z, 0.0f, kPositionTolerance);
+}
+
+TEST(ParseXmlToAdm, InvalidWhenSphericalCoordinateCannotBeParsed) {
+  EXPECT_THAT(ParseXmlToAdm(
+                  R"xml(
+        <audioChannelFormat audioChannelFormatID="AC_00031001">
+          <audioBlockFormat audioBlockFormatID="AB_00031001_00000001">
+            <position coordinate="azimuth">not_a_float</position>
+          </audioBlockFormat>
+        </audioChannelFormat>
+  )xml",
+                  kImportanceThreshold, kAdmFileTypeDefault),
               Not(IsOk()));
 }
 

--- a/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
@@ -13,10 +13,12 @@
 #include "iamf/cli/adm_to_user_metadata/adm/xml_to_adm.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <ios>
 #include <iterator>
+#include <numbers>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -96,7 +98,10 @@ enum AdmBlockFormat {
   kY = 1,
   kZ = 2,
   kAudioBlockLabel = 3,
-  kBlockDefault = 4
+  kAzimuth = 4,
+  kElevation = 5,
+  kDistance = 6,
+  kBlockDefault = 7
 };
 
 // This class is used by xml parser to collect and store various attributes and
@@ -176,11 +181,50 @@ void SetHandlerTag(absl::string_view name, const char** atts,
         handler.audio_block_tag = kY;
       } else if (std::string(atts[i + 1]) == "Z") {
         handler.audio_block_tag = kZ;
+      } else if (std::string(atts[i + 1]) == "azimuth") {
+        handler.audio_block_tag = kAzimuth;
+      } else if (std::string(atts[i + 1]) == "elevation") {
+        handler.audio_block_tag = kElevation;
+      } else if (std::string(atts[i + 1]) == "distance") {
+        handler.audio_block_tag = kDistance;
       }
     }
   } else if (name == "audioBlockFormatID") {
     handler.audio_block_tag = kAudioBlockLabel;
   }
+}
+
+// Derives the cartesian `position` of a block from the spherical coordinates
+// authored for it.
+//
+// The convention is not invented here: `panner.cc` already performs the
+// inverse on every block it reads --
+//
+//   azimuth   = -atan2(x, y)
+//   elevation =  atan2(z, hypot(x, y))
+//   distance  =  |(x, y, z)|
+//
+// so azimuth is measured anticlockwise from front, with +Y front, +X right and
+// +Z up. This function is that mapping run forwards, which keeps a block
+// authored in spherical coordinates and its cartesian twin equivalent through
+// the rest of the pipeline.
+void SetPositionFromSphericalPosition(AudioBlockFormat& audio_block) {
+  constexpr double kDegreesToRadians = std::numbers::pi_v<double> / 180.0;
+  const double azimuth =
+      static_cast<double>(audio_block.spherical_position.azimuth) *
+      kDegreesToRadians;
+  const double elevation =
+      static_cast<double>(audio_block.spherical_position.elevation) *
+      kDegreesToRadians;
+  const double distance =
+      static_cast<double>(audio_block.spherical_position.distance);
+
+  const double horizontal_distance = distance * std::cos(elevation);
+  audio_block.position.x =
+      static_cast<float>(-horizontal_distance * std::sin(azimuth));
+  audio_block.position.y =
+      static_cast<float>(horizontal_distance * std::cos(azimuth));
+  audio_block.position.z = static_cast<float>(distance * std::sin(elevation));
 }
 
 // Sets the attributes of AudioProgramme.
@@ -743,6 +787,31 @@ void XMLCharacterDataHandlerForExpat(void* parser_data, const XML_Char* text,
               absl::SimpleAtof(absl::string_view(text, len),
                                &audio_blocks.back().position.z),
               "position", handler);
+          break;
+        }
+        case kAzimuth:
+        case kElevation:
+        case kDistance: {
+          auto& audio_block = audio_blocks.back();
+          float* coordinate = nullptr;
+          switch (handler.audio_block_tag) {
+            case kAzimuth:
+              coordinate = &audio_block.spherical_position.azimuth;
+              break;
+            case kElevation:
+              coordinate = &audio_block.spherical_position.elevation;
+              break;
+            default:
+              coordinate = &audio_block.spherical_position.distance;
+              break;
+          }
+          const bool parsed =
+              absl::SimpleAtof(absl::string_view(text, len), coordinate);
+          UpdateErrorStatusIfFalse(parsed, "position", handler);
+          if (parsed) {
+            audio_block.has_spherical_position = true;
+            SetPositionFromSphericalPosition(audio_block);
+          }
           break;
         }
         case kAudioBlockLabel: {


### PR DESCRIPTION
Fixes #71.

`AudioBlockFormat` position parsing in `xml_to_adm.cc` accepted only
`coordinate="X"/"Y"/"Z"`. Blocks authored with `azimuth`/`elevation`/`distance`
— equally valid BS.2076, and the EAR/BBC default — were silently dropped, so
every such object stayed at the origin while `encoder_main` returned OK with no
warning.

### The convention is already in the tree

I did not pick a convention. `adm_to_user_metadata/adm/panner.cc` already runs
the inverse on every block it reads:

```c++
auto azimuth = -((atan2(position[0], position[1])) * kRadiansToDegrees);
auto elevation = (atan2(position[2], hypot(position[0], position[1]))) *
                 kRadiansToDegrees;
auto distance = position.norm();
```

so azimuth is measured anticlockwise from front, with +Y front, +X right, +Z
up. This change is that mapping run forwards, which is what keeps a
spherically authored block and its cartesian twin equivalent through the rest
of the pipeline.

Coordinates omitted from a spherical position take the BS.2076 defaults
(`distance` 1, `elevation` 0) rather than zero, so `<position
coordinate="azimuth">` alone resolves to a point on the unit circle.

### Measured

Encoding an 8-object scene authored spherically (`azimuth` 0/90/…,
`elevation` 0, `distance` 1) before and after, decoding both, and comparing the
rendered stereo output: **−7.42 dB per channel**. Origin-collapsed objects are
hot because the panner's `gain/max(distance, 0.5)` law applies at distance 0;
with the positions read, they sit where they were authored.

The scene's cartesian twin — the same geometry authored as
`X`/`Y`/`Z` — is **byte-identical before and after this change**, which is the
control I cared about most: the patch moves the spherical file and nothing
else. Across a 34-file / 70-row ADM ingest matrix, the only outputs that change
are the two rows for the spherically authored file.

### A second, separable change

`CartesianPosition`'s members had no default initializers, and
`ParseXmlToAdm` does:

```c++
AudioBlockFormat audio_block;
CartesianPosition position;
audio_block.position = position;
```

so a block with no readable `<position>` took **indeterminate** values, not the
origin. On this toolchain they happen to be ~0 — the rendered difference from
zero-initialising is about −145 dBFS, one LSB at 24-bit — so this is a
correctness fix rather than a fix for a visible symptom, and nothing guarantees
it stays that way. I've included it here because without it "unparsed position
means the origin" is not actually true, but it is an independent one-line
change and I'm happy to split it out if you'd prefer.

### Tests

Seven cases added to `xml_to_adm_test.cc`: cartesian unchanged, absent position
is a determinate origin, azimuth 90 → `(-1, 0, 0)`, azimuth 0 → `(0, 1, 0)`,
elevation and distance honoured, BS.2076 defaults for omitted coordinates, and
an unparseable spherical coordinate rejected.

`bazel test //iamf/cli/adm_to_user_metadata/...` — 9/9 pass.
`clang-format --style=file` clean.

### Not verified

I have not run the full `//iamf/...` suite, only the `adm_to_user_metadata`
package. I also have not checked whether any consumer depends on the current
behaviour of `has_spherical_position` being absent — it is a new field and
nothing else reads it yet.
