### PR TITLE
adm_to_user_metadata: carry ADM names into mix presentation annotations

### DIFF
--- a/iamf/cli/adm_to_user_metadata/adm/adm_elements.h
+++ b/iamf/cli/adm_to_user_metadata/adm/adm_elements.h
@@ -87,8 +87,9 @@ struct AudioObject {
 
   std::string id;
   std::string name;
-  std::string audio_object_label =
-      std::string(kDefaultLocalizedElementAnnotations);
+  // Empty unless the source ADM carried an `audioObjectLabel`. Consumers fall
+  // back to `name`, and then to `kDefaultLocalizedElementAnnotations`.
+  std::string audio_object_label;
   int32_t importance = kDefaultADMImportance;
   float gain = kDefaultADMGain;
   std::vector<std::string> audio_pack_format_id_refs;

--- a/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.cc
+++ b/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.cc
@@ -35,6 +35,11 @@ namespace adm_to_user_metadata {
 
 namespace {
 
+// Used when the source ADM carried neither an `audioProgrammeLabel` nor an
+// `audioProgrammeName` for this mix presentation.
+constexpr absl::string_view kDefaultLocalizedPresentationAnnotations =
+    "test_mix_pres";
+
 absl::StatusOr<iamf_tools_cli_proto::SoundSystem>
 LookupSoundSystemFromInputLayout(IamfInputLayout layout) {
   // Map which holds the valid loudspeaker layout and the reference sound system
@@ -122,6 +127,22 @@ absl::Status SetDefaultLoudnessLayout(
   return CopyLoudness(loudness_metadata, *layout->mutable_loudness());
 }
 
+// Returns the first non-empty of the authored label and the authored name,
+// falling back to `default_annotation` when the source ADM carried neither.
+// IAMF's annotations are localized strings, so an authored `*Label` is
+// preferred over the corresponding `*Name`.
+absl::string_view LocalizedAnnotationOrDefault(
+    absl::string_view authored_label, absl::string_view authored_name,
+    absl::string_view default_annotation) {
+  if (!authored_label.empty()) {
+    return authored_label;
+  }
+  if (!authored_name.empty()) {
+    return authored_name;
+  }
+  return default_annotation;
+}
+
 absl::Status SubMixAudioElementMetadataBuilder(
     const AudioObject& audio_object, uint32_t audio_element_id,
     uint32_t common_parameter_rate,
@@ -129,7 +150,9 @@ absl::Status SubMixAudioElementMetadataBuilder(
   sub_mix_audio_element.set_audio_element_id(audio_element_id);
 
   sub_mix_audio_element.add_localized_element_annotations(
-      audio_object.audio_object_label);
+      std::string(LocalizedAnnotationOrDefault(
+          audio_object.audio_object_label, audio_object.name,
+          AudioObject::kDefaultLocalizedElementAnnotations)));
 
   auto* rendering_config = sub_mix_audio_element.mutable_rendering_config();
 
@@ -215,14 +238,18 @@ bool IsChannelBasedAndNotStereo(IamfInputLayout input_layout) {
 
 // Sets the required textproto fields for mix_presentation_metadata.
 absl::Status MixPresentationHandler::PopulateMixPresentation(
-    int32_t mix_presentation_id, const std::vector<AudioObject>& audio_objects,
+    int32_t mix_presentation_id, absl::string_view audio_programme_name,
+    absl::string_view audio_programme_label,
+    const std::vector<AudioObject>& audio_objects,
     const LoudnessMetadata& loudness_metadata,
     iamf_tools_cli_proto::MixPresentationObuMetadata&
         mix_presentation_obu_metadata) {
   mix_presentation_obu_metadata.set_mix_presentation_id(mix_presentation_id);
   mix_presentation_obu_metadata.add_annotations_language("en-us");
   mix_presentation_obu_metadata.add_localized_presentation_annotations(
-      "test_mix_pres");
+      std::string(LocalizedAnnotationOrDefault(
+          audio_programme_label, audio_programme_name,
+          kDefaultLocalizedPresentationAnnotations)));
 
   auto& mix_presentation_sub_mix =
       *mix_presentation_obu_metadata.add_sub_mixes();

--- a/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.h
+++ b/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "iamf/cli/adm_to_user_metadata/adm/adm_elements.h"
 #include "iamf/cli/proto/mix_presentation.pb.h"
 
@@ -52,13 +53,19 @@ class MixPresentationHandler {
   /*!\brief Populates a `MixPresentationObuMetadata` proto.
    *
    * \param mix_presentation_id Mix presentation ID to generate.
+   * \param audio_programme_name `audioProgrammeName` of the source programme,
+   *        or empty when there was none.
+   * \param audio_programme_label `audioProgrammeLabel` of the source
+   *        programme, or empty when there was none. Preferred over
+   *        `audio_programme_name` for the localized annotation.
    * \param audio_objects Audio objects for this mix presentation.
    * \param loudness_metadata Loudness metadata.
    * \param mix_presentation_obu_metadata Metadata to populate.
    * \return `absl::OkStatus()` on success. A specific error on failure.
    */
   absl::Status PopulateMixPresentation(
-      int32_t mix_presentation_id,
+      int32_t mix_presentation_id, absl::string_view audio_programme_name,
+      absl::string_view audio_programme_label,
       const std::vector<AudioObject>& audio_objects,
       const LoudnessMetadata& loudness_metadata,
       iamf_tools_cli_proto::MixPresentationObuMetadata&

--- a/iamf/cli/adm_to_user_metadata/iamf/tests/mix_presentation_handler_test.cc
+++ b/iamf/cli/adm_to_user_metadata/iamf/tests/mix_presentation_handler_test.cc
@@ -72,7 +72,9 @@ TEST(Constructor, DoesNotCrash) {
 
 iamf_tools_cli_proto::MixPresentationObuMetadata GetMixObuMetataExpectOk(
     const std::vector<AudioObject>& audio_objects = {GetStereoAudioObject()},
-    LoudnessMetadata loudness_metadata = LoudnessMetadata()) {
+    LoudnessMetadata loudness_metadata = LoudnessMetadata(),
+    absl::string_view audio_programme_name = "",
+    absl::string_view audio_programme_label = "") {
   std::map<std::string, uint32_t> audio_object_id_to_audio_element_id;
   // Assign audio element IDs sequentially.
   uint32_t audio_element_id = 0;
@@ -84,10 +86,11 @@ iamf_tools_cli_proto::MixPresentationObuMetadata GetMixObuMetataExpectOk(
                                  audio_object_id_to_audio_element_id);
 
   iamf_tools_cli_proto::MixPresentationObuMetadata mix_presentation_metadata;
-  EXPECT_THAT(handler.PopulateMixPresentation(kMixPresentationId, audio_objects,
-                                              loudness_metadata,
-                                              mix_presentation_metadata),
-              IsOk());
+  EXPECT_THAT(
+      handler.PopulateMixPresentation(
+          kMixPresentationId, audio_programme_name, audio_programme_label,
+          audio_objects, loudness_metadata, mix_presentation_metadata),
+      IsOk());
 
   return mix_presentation_metadata;
 }
@@ -103,6 +106,68 @@ TEST(PopulateMixPresentation, PopulatesLabels) {
   EXPECT_FALSE(mix_presentation_metadata.annotations_language(0).empty());
   EXPECT_FALSE(
       mix_presentation_metadata.localized_presentation_annotations(0).empty());
+}
+
+TEST(PopulateMixPresentation,
+     UsesTheAudioProgrammeNameForThePresentationAnnotation) {
+  const auto& mix_presentation_metadata = GetMixObuMetataExpectOk(
+      {GetStereoAudioObject()}, LoudnessMetadata(), "MainMix");
+
+  EXPECT_EQ(mix_presentation_metadata.localized_presentation_annotations(0),
+            "MainMix");
+}
+
+TEST(PopulateMixPresentation,
+     PrefersTheAudioProgrammeLabelOverTheAudioProgrammeName) {
+  const auto& mix_presentation_metadata = GetMixObuMetataExpectOk(
+      {GetStereoAudioObject()}, LoudnessMetadata(), "MainMix", "Main Mix (EN)");
+
+  EXPECT_EQ(mix_presentation_metadata.localized_presentation_annotations(0),
+            "Main Mix (EN)");
+}
+
+TEST(PopulateMixPresentation,
+     FallsBackToADefaultPresentationAnnotationWhenTheAdmHasNoName) {
+  const auto& mix_presentation_metadata = GetMixObuMetataExpectOk();
+
+  EXPECT_FALSE(
+      mix_presentation_metadata.localized_presentation_annotations(0).empty());
+}
+
+TEST(PopulateMixPresentation, UsesTheAudioObjectNameForTheElementAnnotation) {
+  AudioObject audio_object = GetStereoAudioObject();
+  audio_object.name = "Dialogue";
+  const auto& mix_presentation_metadata =
+      GetMixObuMetataExpectOk({audio_object});
+
+  EXPECT_EQ(mix_presentation_metadata.sub_mixes(0)
+                .audio_elements(0)
+                .localized_element_annotations(0),
+            "Dialogue");
+}
+
+TEST(PopulateMixPresentation,
+     PrefersTheAudioObjectLabelOverTheAudioObjectName) {
+  AudioObject audio_object = GetStereoAudioObject();
+  audio_object.name = "Dialogue";
+  audio_object.audio_object_label = "Dialogue (EN)";
+  const auto& mix_presentation_metadata =
+      GetMixObuMetataExpectOk({audio_object});
+
+  EXPECT_EQ(mix_presentation_metadata.sub_mixes(0)
+                .audio_elements(0)
+                .localized_element_annotations(0),
+            "Dialogue (EN)");
+}
+
+TEST(PopulateMixPresentation,
+     FallsBackToADefaultElementAnnotationWhenTheAdmHasNoName) {
+  const auto& mix_presentation_metadata = GetMixObuMetataExpectOk();
+
+  EXPECT_FALSE(mix_presentation_metadata.sub_mixes(0)
+                   .audio_elements(0)
+                   .localized_element_annotations(0)
+                   .empty());
 }
 
 TEST(PopulateMixPresentation, PopulatesStereoSubmix) {

--- a/iamf/cli/adm_to_user_metadata/iamf/user_metadata_generator.cc
+++ b/iamf/cli/adm_to_user_metadata/iamf/user_metadata_generator.cc
@@ -133,7 +133,8 @@ UserMetadataGenerator::GenerateUserMetadata(
 
     if (const auto& status =
             iamf->mix_presentation_handler_.PopulateMixPresentation(
-                kFirstMixPresentationId, audio_objects, LoudnessMetadata(),
+                kFirstMixPresentationId, /*audio_programme_name=*/"",
+                /*audio_programme_label=*/"", audio_objects, LoudnessMetadata(),
                 *user_metadata.add_mix_presentation_metadata());
         !status.ok()) {
       return status;
@@ -143,7 +144,14 @@ UserMetadataGenerator::GenerateUserMetadata(
          iamf->mix_presentation_id_to_audio_objects_and_metadata_) {
       if (const auto& status =
               iamf->mix_presentation_handler_.PopulateMixPresentation(
-                  mix_presentation_id, audio_objects_and_metadata.audio_objects,
+                  mix_presentation_id,
+                  adm_.audio_programmes[audio_objects_and_metadata
+                                            .original_audio_programme_index]
+                      .name,
+                  adm_.audio_programmes[audio_objects_and_metadata
+                                            .original_audio_programme_index]
+                      .audio_programme_label,
+                  audio_objects_and_metadata.audio_objects,
                   adm_.audio_programmes[audio_objects_and_metadata
                                             .original_audio_programme_index]
                       .loudness_metadata,


### PR DESCRIPTION
Fixes #73.

Source ADM names did not survive ingest. The produced bitstream's annotations
were the metadata generator's template strings — `test_mix_pres` and
`test_sub_mix_0_audio_element_0` — no matter what the source was called.
Multi-programme *structure* survived correctly (N programmes → N mix
presentations), but every label was a placeholder, so language- and
label-driven presentation selection had nothing real to display.

### Change

Prefer the authored localized label, then the authored name, then the existing
template string — for both the presentation annotation and each sub-mix audio
element annotation:

```
audioProgrammeLabel → audioProgrammeName → "test_mix_pres"
audioObjectLabel    → audioObjectName    → "test_sub_mix_0_audio_element_0"
```

IAMF's annotations are localized strings, so the authored `*Label` is preferred
over the corresponding `*Name`. `PopulateMixPresentation` now takes the
programme's name and label; the no-programme path passes empty strings and
therefore keeps today's output exactly.

`AudioObject::audio_object_label` no longer defaults to the template constant.
It is empty unless the source carried an `audioObjectLabel`, and the fallback
happens where the annotation is written, so "was a label authored?" is
answerable rather than being conflated with the default.

### Measured

On a two-programme file (`MainMix`, `AltMix`, bed named `Bed_5dot1`), encoded
before and after and read back with `strings`:

| | before | after |
|---|---|---|
| `MainMix` | 0 | 1 |
| `AltMix` | 0 | 1 |
| `Bed_5dot1` | 0 | 2 |
| `test_mix_pres` | 2 | 0 |
| `test_sub_mix_0_audio_element_0` | 2 | 0 |

`probe_main` still reports **2 mix presentations** for that file, so the
structure is unchanged and only the labels move.

Across a 34-file / 70-row ADM ingest matrix there are **no disposition
changes**. 55 rows change output size, which is the annotation strings changing
length — that is the fix rather than a side effect.

### One unrelated observation

While checking for collateral I saw two rows (`dlb_bed_5dot1_labelonly` and
`dlb_bed_7dot1dot2`, `enhanced`) report SIGABRT on one run and SIGSEGV on the
next. Running the **same binary on the same input four times** reproduces the
flip with no code change at all, so it predates this PR and is not caused by
it — but a crash whose signal is not stable run to run is worth someone
looking at independently. Those files already crash under `enhanced` on `main`;
this change does not alter whether they crash.

### Tests

Six cases added to `mix_presentation_handler_test.cc`: programme name used,
programme label preferred over name, default when neither is present, and the
same three for audio object annotations.

`bazel test //iamf/cli/adm_to_user_metadata/...` — 9/9 pass.
`clang-format --style=file` clean.

### Not verified

Only the `adm_to_user_metadata` package's tests were run, not the full
`//iamf/...` suite. I have not checked whether any downstream consumer relies
on the template strings being present verbatim.
