### PR TITLE
validation: give mlsd_comparator a BUILD file

### DIFF
--- a/validation/mlsd_comparator/BUILD
+++ b/validation/mlsd_comparator/BUILD
@@ -1,0 +1,20 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+package(default_visibility = ["//validation:__subpackages__"])
+
+py_library(
+    name = "mlsd_comparator",
+    srcs = ["mlsd_comparator.py"],
+)
+
+py_binary(
+    name = "mlsd_comparator_main",
+    srcs = ["mlsd_comparator_main.py"],
+    main = "mlsd_comparator_main.py",
+    deps = [
+        ":mlsd_comparator",
+        "@abseil-py//absl:app",
+        "@abseil-py//absl/flags",
+        "@abseil-py//absl/logging",
+    ],
+)


### PR DESCRIPTION
`validation/iamf_verifier/BUILD` declares a dependency on
`//validation/mlsd_comparator`, but that directory has no BUILD file, so it
is not a package. Every other directory under `validation/` has one. The
result is that `bazel build //...` and `bazel test //...` fail during
analysis on a clean checkout:

  ERROR: validation/iamf_verifier/BUILD:5:10: no such package
         'validation/mlsd_comparator': BUILD file not found in any of the
         following directories. Add a BUILD file to a directory to mark it
         as a package.

Add the missing file: a `py_library` under the name the dependency already
uses, and a `py_binary` for `mlsd_comparator_main.py`, matching how
`opus_hoa` and `iamf_loudness_comparator` expose their own mains.

`mlsd_comparator_test.py` is deliberately not wired up here. It imports
numpy and scipy, and this repository does not express its Python
requirements to Bazel -- there is no pip lock and no `pip.parse` extension
in MODULE.bazel -- so a `py_test` would fail at runtime rather than pass.
Wiring the Python requirements is a larger change and is left separate.
Closes #92

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.