### PR TITLE
iamf/cli/tests: give encoder_main_lib_test a moderate timeout

### DIFF
--- a/iamf/cli/tests/BUILD
+++ b/iamf/cli/tests/BUILD
@@ -383,6 +383,7 @@ cc_test(
 cc_test(
     name = "encoder_main_lib_test",
     size = "small",
+    timeout = "moderate",
     srcs = ["encoder_main_lib_test.cc"],
     data = [
         "//iamf/cli/testdata:input_wav_files",


### PR DESCRIPTION
size = "small" gives each shard a 60 second timeout. On an otherwise idle 8-core arm64 machine the slowest of the 32 shards takes 52.1s, with three shards above 40s — 87% of the ceiling, and no margin at all. Under the contention of a full bazel test //..., where the 32 shards compete with the rest of the build, shards cross the ceiling and the target reports TIMEOUT: two of 32 on one run and one of 32 on the next, against the same tree, with every test case passing when the target is run on its own.

Nothing is flaky about the test itself; the ceiling is simply too low for what it does. Setting timeout = "moderate" raises it to 300s while leaving size — and so the peak local resource usage Bazel assumes when scheduling the shards — where every other test in this repository has it.

Measured again on this branch, running the target alone rather than as part of //...: the target passes in 65.1s wall, with twelve shards reporting 18.4s to 28.2s of execution time excluding overhead. That is the uncontended case, and it is already a third to a half of the 60s ceiling before any other action competes for a core.

Testing: macOS arm64, Bazel 8.5.1. bazel test //iamf/cli/tests:encoder_main_lib_test passes; bazel query --output=build confirms size = "small", timeout = "moderate", shard_count = 32.

Closes #93.