### PR TITLE
Allow the AAC bitrate to be configured, like Opus

### DIFF
--- a/iamf/cli/codec/aac_encoder.cc
+++ b/iamf/cli/codec/aac_encoder.cc
@@ -123,7 +123,21 @@ absl::Status ConfigureAacEncoder(
       absl::StrCat("Failed to configure encoder channel mode= ",
                    aac_channel_mode)));
 
-  // Let AACENC_BITRATE be configured automatically.
+  // Leave AACENC_BITRATE alone unless the user asked for a specific rate;
+  // `fdk_aac` picks a sensible default for the configured channel mode and
+  // sample rate when the parameter is never set.
+  if (encoder_metadata.bitrate() != 0) {
+    if (encoder_metadata.bitrate() < 0) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("AAC bitrate must not be negative. Got bitrate= ",
+                       encoder_metadata.bitrate()));
+    }
+    RETURN_IF_NOT_OK(AacEncErrorToAbslStatus(
+        aacEncoder_SetParam(encoder, AACENC_BITRATE,
+                            static_cast<UINT>(encoder_metadata.bitrate())),
+        absl::StrCat("Failed to configure encoder bitrate= ",
+                     encoder_metadata.bitrate())));
+  }
 
   // Set some arguments configured by the user-provided `encoder_metadata_`.
   RETURN_IF_NOT_OK(AacEncErrorToAbslStatus(
@@ -192,6 +206,20 @@ absl::Status AacEncoder::InitializeEncoder() {
   // Validate the configuration matches expected results.
   RETURN_IF_NOT_OK(ValidateEncoderInfo(channel_count_.num_channels(),
                                        num_samples_per_frame_, encoder_));
+
+  // `fdk_aac` bounds the bitrate by the maximum AAC frame size and adjusts a
+  // request that falls outside that range without reporting an error, so read
+  // back what it settled on and say so rather than letting the user believe
+  // the requested rate was used.
+  if (encoder_metadata_.bitrate() != 0) {
+    const UINT effective_bitrate =
+        aacEncoder_GetParam(encoder_, AACENC_BITRATE);
+    if (effective_bitrate != static_cast<UINT>(encoder_metadata_.bitrate())) {
+      ABSL_LOG(WARNING) << "`fdk_aac` adjusted the requested AAC bitrate from "
+                        << encoder_metadata_.bitrate() << " to "
+                        << effective_bitrate << " bits per second.";
+    }
+  }
 
   return absl::OkStatus();
 }

--- a/iamf/cli/proto/codec_config.proto
+++ b/iamf/cli/proto/codec_config.proto
@@ -100,6 +100,20 @@ message AacEncoderMetadata {
   bool enable_afterburner = 2 [default = true];
 
   int32 signaling_mode = 3 [default = 2];
+
+  // Target bitrate for the substream, in bits per second. IAMF restricts AAC
+  // to one or two channels, so this is the rate for the whole substream and
+  // not a per-channel rate.
+  //
+  // When this is left at 0, `fdk_aac` selects a bitrate itself, which for
+  // AAC-LC is 1.5 bits per sample -- 72000 bits per second for one channel at
+  // 48 kHz, and 144000 for two.
+  //
+  // `fdk_aac` bounds the usable range by the maximum AAC frame size and
+  // adjusts a request that falls outside it without reporting an error. The
+  // encoder reads the effective rate back after initialization and logs a
+  // warning when it differs from the requested one.
+  int32 bitrate = 4;
 }
 
 message AacDecoderSpecificInfo {


### PR DESCRIPTION
`AacEncoderMetadata` has no bitrate field, so an AAC substream is always
encoded at whatever `fdk_aac` picks for the channel mode and sample rate
(1.5 bits per sample for AAC-LC), with no way to ask for a different rate.
Opus has had `target_bitrate_per_channel` and friends since the beginning.
This is the part of #25 that outlived the bad-default fix in 1b21e977.

Add `AacEncoderMetadata.bitrate`, in bits per second for the whole
substream since IAMF restricts AAC to one or two channels. Leaving it at 0
keeps today's behaviour exactly: `AACENC_BITRATE` is never set and the
output is byte-identical.

`fdk_aac` silently adjusts a request that exceeds what the maximum AAC
frame size allows, so the effective rate is read back after initialization
and a warning names both values.

Bug: #25
Closes #25

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.