### PR TITLE
adm_to_user_metadata: keep each audioObject's own wav channels when objects are filtered

### DIFF
--- a/iamf/cli/adm_to_user_metadata/adm/adm_elements.h
+++ b/iamf/cli/adm_to_user_metadata/adm/adm_elements.h
@@ -89,6 +89,16 @@ struct AudioObject {
   std::vector<std::string> audio_pack_format_id_refs;
   std::vector<std::string> audio_comple_object_id_ref;
   std::vector<std::string> audio_track_uid_ref;
+  // 0-based index of this object's first audioTrack in the wav's original
+  // channel order, counting every audioObject in declaration order. Stamped
+  // once by `AssignOriginalTrackIndices()` (xml_to_adm.cc) *before*
+  // `RemoveLowImportanceAndInvalidAudioObjects()` can drop any object from
+  // `ADM::audio_objects`. The default-ADM wav splicer
+  // (wav_file_splicer.cc) relies on this to keep reading each surviving
+  // object's own physical wav channel(s) when an earlier object is filtered
+  // out by --adm_importance_threshold (or is invalid) and the filtered
+  // object is not the last one. Left at -1 if that pass has not run.
+  int32_t first_audio_track_index = -1;
 };
 
 // This structure holds the attributes of an audio pack format in ADM.

--- a/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
@@ -69,17 +69,33 @@ constexpr int kMaxLfeChannelsAllowed =
     kMaxChannelsPerMixBaseEnhanced - kOutputWavChannels;
 
 // Creates a map for the audioObject(s) and the audioTrack(s) present within.
+//
+// The returned indices are positions in the *original* (pre-importance/
+// validity-filtering) wav channel layout -- i.e. `audio_object`s here may be
+// a strict subset of the file's declared audioObjects, with some removed by
+// `RemoveLowImportanceAndInvalidAudioObjects()`. Deriving the indices from
+// `first_audio_track_index` (stamped before that removal; see
+// `AssignOriginalTrackIndices()` in xml_to_adm.cc) rather than by counting
+// tracks sequentially over whatever objects happen to remain is required:
+// removing an object does not relocate any other object's samples within
+// the input wav, so a surviving object must keep the channel position it
+// always had, gap and all, even when that leaves it non-adjacent to the
+// previous surviving object.
 std::vector<std::vector<int32_t>> GetAudioTracksForAudioObjects(
     const std::vector<struct AudioObject>& audio_objects) {
   std::vector<std::vector<int32_t>> audio_tracks_for_audio_objects(
       audio_objects.size(), std::vector<int32_t>());
   int32_t audio_object_index = -1;
-  int32_t audio_track_index = -1;
   for (const auto& audio_object : audio_objects) {
     auto& audio_tracks_for_audio_object =
         audio_tracks_for_audio_objects[++audio_object_index];
-    for (auto unused_audio_track : audio_object.audio_track_uid_ref) {
-      audio_tracks_for_audio_object.push_back(++audio_track_index);
+    ABSL_CHECK_GE(audio_object.first_audio_track_index, 0)
+        << "first_audio_track_index for audio_object_id=" << audio_object.id
+        << " was never assigned. AssignOriginalTrackIndices() must run "
+           "before any audio objects are removed from the ADM.";
+    int32_t audio_track_index = audio_object.first_audio_track_index;
+    for (size_t i = 0; i < audio_object.audio_track_uid_ref.size(); ++i) {
+      audio_tracks_for_audio_object.push_back(audio_track_index++);
     }
   }
   return audio_tracks_for_audio_objects;
@@ -753,32 +769,46 @@ absl::Status SpliceWavFilesFromAdm(
     // audio tracks, based on the mapping specified in
     // 'audio_tracks_for_audio_objects'. Write the audio track data to
     // corresponding `WavWriter`s.
+    //
+    // Each iteration reads one full interleaved frame of the *original*
+    // wav -- every input channel, including any that belong to an object
+    // filtered out of `audio_tracks_for_audio_objects` -- and then scatters
+    // each surviving object's own track(s) out of that frame by their
+    // recorded (pre-filtering) channel index. Always advancing the stream by
+    // a whole original frame keeps every subsequent frame boundary aligned
+    // regardless of how many objects were filtered; indexing by recorded
+    // position, rather than by arrival order in the (already-filtered)
+    // `audio_tracks_for_audio_objects`, keeps a surviving object reading its
+    // own channel(s) instead of a filtered-out neighbor's.
     const int32_t bytes_per_sample =
         static_cast<int32_t>(wav_file_fmt.bits_per_sample) / kBitsPerByte;
     const int32_t channels = wav_file_fmt.num_channels;
+    const size_t bytes_per_frame =
+        static_cast<size_t>(bytes_per_sample) * channels;
+    std::vector<char> frame(bytes_per_frame);
     for (size_t data_chunk_pos = 0; data_chunk_pos < data_chunk_info->size;
-         data_chunk_pos += static_cast<size_t>(bytes_per_sample) * channels) {
+         data_chunk_pos += bytes_per_frame) {
+      if (!input_stream.read(frame.data(), frame.size())) {
+        AbortAllWavWriters(audio_object_index_to_wav_writer);
+        return absl::OutOfRangeError(
+            "Reached end of stream before the implied end of the `data` "
+            "chunk.");
+      }
+
       for (size_t audio_object_index = 0;
            audio_object_index < audio_tracks_for_audio_objects.size();
            ++audio_object_index) {
-        // Read in the samples for the current audio object.
-        std::vector<char> sample(
-            static_cast<size_t>(bytes_per_sample) *
-            audio_tracks_for_audio_objects[audio_object_index].size());
-
-        if (!input_stream.read(sample.data(), sample.size())) {
-          AbortAllWavWriters(audio_object_index_to_wav_writer);
-          return absl::OutOfRangeError(
-              "Reached end of stream before the implied end of the `data` "
-              "chunk.");
-        }
-
-        // Store the samples in the buffer.
         auto& samples_for_audio_object =
             interlaced_samples_for_audio_objects[audio_object_index];
-        std::transform(sample.begin(), sample.end(),
-                       std::back_inserter(samples_for_audio_object),
-                       [](char c) { return static_cast<uint8_t>(c); });
+        for (const int32_t track_index :
+             audio_tracks_for_audio_objects[audio_object_index]) {
+          const size_t byte_offset =
+              static_cast<size_t>(track_index) * bytes_per_sample;
+          std::transform(frame.begin() + byte_offset,
+                         frame.begin() + byte_offset + bytes_per_sample,
+                         std::back_inserter(samples_for_audio_object),
+                         [](char c) { return static_cast<uint8_t>(c); });
+        }
 
         // Occasionally flush the buffer to the corresponding wav writer.
         if (samples_for_audio_object.size() >= kSizeToFlush) {

--- a/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
@@ -323,6 +323,25 @@ absl::Status SetAudioBlockValue(absl::string_view key, absl::string_view value,
   return absl::OkStatus();
 }
 
+// Stamps every audioObject with the 0-based index of its first audioTrack in
+// the wav's original, physical channel order (i.e. counting every object's
+// audio_track_uid_ref in file order, with no objects removed). MUST run
+// before `RemoveLowImportanceAndInvalidAudioObjects()`, which subsequently
+// erases whole objects from `adm.audio_objects` -- erasing an object can
+// never change where the *remaining* objects' samples actually live in the
+// input wav, so their original offsets have to be captured first. Consumed
+// by wav_file_splicer.cc's `GetAudioTracksForAudioObjects()` so a surviving
+// object keeps reading its own channel(s) instead of sliding into whatever
+// position it happens to land on in the post-filtering list.
+void AssignOriginalTrackIndices(ADM& adm) {
+  int32_t next_track_index = 0;
+  for (auto& audio_object : adm.audio_objects) {
+    audio_object.first_audio_track_index = next_track_index;
+    next_track_index +=
+        static_cast<int32_t>(audio_object.audio_track_uid_ref.size());
+  }
+}
+
 // Removes objects from the ADM structure based on the given importance
 // threshold. Also, removes audio objects with IDs found in the set of invalid
 // audio objects.
@@ -1000,6 +1019,7 @@ absl::StatusOr<ADM> ParseXmlToAdm(absl::string_view xml_data,
                                             xml_data.length(), true)) {
     case XML_STATUS_OK:
       SetChannelIndices(handler.adm);
+      AssignOriginalTrackIndices(handler.adm);
       ValidateAudioObjects(handler.adm, handler);
       RemoveLowImportanceAndInvalidAudioObjects(importance_threshold, handler);
       if (!handler.status.ok()) {


### PR DESCRIPTION
`ParseXmlToAdm` erases audioObjects that fall below the importance threshold
or fail validation, and the default-ADM splicer then rebuilds the object to
track mapping by counting sequentially over whatever objects survived:

    for (const auto& audio_object : audio_objects) {
      for (auto unused_audio_track : audio_object.audio_track_uid_ref) {
        audio_tracks_for_audio_object.push_back(++audio_track_index);

Nothing resolves an `audioTrackUID` to a physical channel -- the `chna` chunk
is not parsed -- so removing an object silently renumbers every later object
onto a different input channel. The read loop compounds it: its stride is the
original frame size while each iteration consumes only the surviving tracks'
bytes, so the stream cursor slips by one channel per frame and every surviving
object, including the first, rotates through all of the input's channels.

Removing an object does not move any other object's samples in the wav, so
record each object's first track index before the filtering pass and address
channels by that. The read loop now takes a whole original frame and scatters
each object's own channels out of it, which keeps the frame boundary aligned
whatever was filtered.

Measured on a four-object default ADM whose channels carry 313, 452, 591 and
730 Hz: at `--adm_importance_threshold=0` the output is byte-identical before
and after. At a threshold that drops the second object, the three surviving
objects previously carried no assigned tone at all; they now carry 313, 591
and 730 Hz.
Closes #85

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.