### PR TITLE
adm_to_user_metadata: support 7.1.4 in Dolby DirectSpeakers packs

### DIFF
--- a/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
@@ -49,6 +49,12 @@ constexpr absl::string_view kTypeDefinitionBinaural = "0005";
 
 constexpr size_t kAudioPackFormatIdRefLength = 11;
 
+// Largest number of channels in any layout `kValidPackLayouts` accepts, which
+// is 7.1.4. The pack layout itself is what decides whether a Dolby
+// DirectSpeakers pack is supported; this only bounds the work done before
+// that check.
+constexpr size_t kMaxDirectSpeakersChannels = 12;
+
 // It defines adm elements.
 enum AdmElement {
   kAudioProgramme = 0,
@@ -399,6 +405,10 @@ absl::StatusOr<std::string> CreatePackLayout(
       {"RoomCentricRightRearSurround", "Rrs"},
       {"RoomCentricLeftTopSurround", "Lts"},
       {"RoomCentricRightTopSurround", "Rts"},
+      {"RoomCentricLeftTopFront", "Ltf"},
+      {"RoomCentricRightTopFront", "Rtf"},
+      {"RoomCentricLeftTopRear", "Ltr"},
+      {"RoomCentricRightTopRear", "Rtr"},
       {"RoomCentricLeftSurround", "Ls"},
       {"RoomCentricRightSurround", "Rs"}};
 
@@ -433,6 +443,8 @@ absl::Status ValidatePackLayout(const std::string& pack_layout) {
           {"L,R,C,LFE,Lss,Rss,Lrs,Rrs"},
           {"L,R,C,Lss,Rss,Lrs,Rrs,Lts,Rts"},
           {"L,R,C,LFE,Lss,Rss,Lrs,Rrs,Lts,Rts"},
+          {"L,R,C,Lss,Rss,Lrs,Rrs,Ltf,Rtf,Ltr,Rtr"},
+          {"L,R,C,LFE,Lss,Rss,Lrs,Rrs,Ltf,Rtf,Ltr,Rtr"},
       });
 
   if (!kValidPackLayouts->contains(pack_layout)) {
@@ -513,15 +525,17 @@ absl::Status ValidateAdmObjectForDolbyAdm(const ADM& adm,
     }
   } else {
     ABSL_CHECK_EQ(type_definition, kTypeDefinitionDirectSpeakers);
-    if (num_tracks_in_object > 10) {
-      return absl::InvalidArgumentError(
+    if (num_tracks_in_object > kMaxDirectSpeakersChannels) {
+      return absl::InvalidArgumentError(absl::StrCat(
           "Maximum number of occurrences of track UID refs for DirectSpeakers "
-          "is 10.");
+          "is ",
+          kMaxDirectSpeakersChannels, "."));
     }
-    if (num_channels_in_pack > 10) {
-      return absl::InvalidArgumentError(
+    if (num_channels_in_pack > kMaxDirectSpeakersChannels) {
+      return absl::InvalidArgumentError(absl::StrCat(
           "Maximum number of occurrences of channel ID refs for DirectSpeakers "
-          "is 10.");
+          "is ",
+          kMaxDirectSpeakersChannels, "."));
     }
 
     // Create an audio pack layout string based on channel names present within


### PR DESCRIPTION
A 7.1.4 bed authored as a Dolby DirectSpeakers pack is rejected: the channel
name map stops at `Lts`/`Rts`, the pack-layout whitelist tops out at 7.1.2,
and the DirectSpeakers reference caps are 10 while 7.1.4 needs 12. The same
layout authored against the BS.2094 common definitions is accepted --
`IsLoudspeakerLayoutValid` already lists `"0017"` -- so the two ADM dialects
disagree about a layout both can express.

The rejection is also the precondition for the crash in #84: the object is
dropped, `ParseXmlToAdm` still returns OK, and the empty audioObject list is
what the metadata pass then indexes into. Closing the gap removes that
trigger; #84's guard is still needed, because objects are dropped by several
other routes.

Add the four height channel names, add the two 7.1.4 pack layouts, and derive
the reference caps from the widest whitelisted layout instead of repeating a
literal 10 -- the whitelist is what actually decides support, so the caps only
bound the work done before it is consulted.

Measured: `dlb_bed_7dot1dot4` under `--adm_profile_version=base` goes from
SIGSEGV at HEAD to `rc 0`, and decodes to 7.1.4. `cd_bed_7dot1dot4`,
`dlb_bed_7dot1dot2`, `dlb_bed_5dot1` and `dlb_obj_static28` are all
byte-identical.
Closes #89

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.