### PR TITLE
adm_to_user_metadata: stop reading past the temp buffer's logical size

### DIFF
--- a/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
@@ -597,13 +597,18 @@ absl::Status SeparateLfeChannels(const std::filesystem::path& output_file_path,
   size_t num_samples_to_read = kSizeToFlush;
   std::vector<char> temp_buffer(num_samples_to_read * bytes_per_sample *
                                 num_channels);
+  // The buffer is reused for every chunk; its logical size is the chunk size
+  // and must stay constant for the lifetime of the loop below. Bind it once
+  // rather than querying the vector, so that the read size, the loop stride
+  // and the buffer's extent cannot drift apart.
+  const size_t bytes_per_read = temp_buffer.size();
 
   // Perform the file read in chunks and use the temporary buffer for further
   // processing.
   for (size_t data_chunk_pos = 0; data_chunk_pos < data_chunk_info.size;
-       data_chunk_pos += temp_buffer.capacity()) {
+       data_chunk_pos += bytes_per_read) {
     const size_t bytes_to_read =
-        std::min(temp_buffer.capacity(), data_chunk_info.size - data_chunk_pos);
+        std::min(bytes_per_read, data_chunk_info.size - data_chunk_pos);
     if (!input_stream.read(temp_buffer.data(), bytes_to_read)) {
       AbortAllWavWriters(nonlfe_lfe_wav_writer);
       return absl::OutOfRangeError(
@@ -614,7 +619,6 @@ absl::Status SeparateLfeChannels(const std::filesystem::path& output_file_path,
     RETURN_IF_NOT_OK(FlushLfeNonLfeWavs(
         temp_buffer, bytes_to_read, num_channels, bytes_per_sample,
         *segment_layout, nonlfe_lfe_wav_writer));
-    temp_buffer.clear();
   }
   return absl::OkStatus();
 }


### PR DESCRIPTION
`SeparateLfeChannels` sizes its per-chunk read and its loop stride from
`temp_buffer.capacity()`, then calls `temp_buffer.clear()` at the end of
every iteration. From the second iteration onwards the buffer's size is
0 while its capacity is unchanged, so the `read()` at the top of the loop
writes `capacity()` bytes into a container whose logical extent is empty.
Under a standard library that annotates vector storage this is reported as
an AddressSanitizer container-overflow; it also relies on the unspecified
guarantee that a count-constructed vector has `capacity() == size()`.

The `clear()` is dead: `FlushLfeNonLfeWavs` takes the buffer by const
reference and reads only `[0, bytes_to_read)`, which `read()` overwrites
on every iteration. Drop it, and bind the chunk size once so that the read
size, the loop stride and the buffer's extent cannot drift apart.

The I/O sizes are unchanged: `bytes_per_read` takes the same value the
code previously obtained from `capacity()`.

Fixes #83.
Closes #83

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.