### PR TITLE
adm_to_user_metadata: give each mix gain parameter its own ID

### DIFF
--- a/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.cc
+++ b/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.cc
@@ -137,7 +137,7 @@ absl::string_view LocalizedAnnotationOrDefault(
 
 absl::Status SubMixAudioElementMetadataBuilder(
     const AudioObject& audio_object, uint32_t audio_element_id,
-    uint32_t common_parameter_rate,
+    uint32_t common_parameter_rate, uint32_t parameter_id,
     iamf_tools_cli_proto::SubMixAudioElement& sub_mix_audio_element) {
   sub_mix_audio_element.set_audio_element_id(audio_element_id);
 
@@ -171,7 +171,7 @@ absl::Status SubMixAudioElementMetadataBuilder(
 
   auto* param_definition =
       mix_gain_param_definition->mutable_param_definition();
-  param_definition->set_parameter_id(0);
+  param_definition->set_parameter_id(parameter_id);
   param_definition->set_parameter_rate(common_parameter_rate);
   param_definition->set_param_definition_mode(1);
 
@@ -245,9 +245,16 @@ absl::Status MixPresentationHandler::PopulateMixPresentation(
   auto& mix_presentation_sub_mix =
       *mix_presentation_obu_metadata.add_sub_mixes();
   for (const auto& audio_object : audio_objects) {
+    // Each `element_mix_gain` is a distinct parameter: it carries that audio
+    // element's own `default_mix_gain`, taken from the audioObject's authored
+    // `<gain>`. Sharing one parameter ID between them, or with the sub-mix's
+    // `output_mix_gain` below, describes one parameter with conflicting
+    // definitions and is rejected downstream by
+    // `CollectAndValidateParamDefinitions`.
     const auto status = SubMixAudioElementMetadataBuilder(
         audio_object, audio_object_id_to_audio_element_id_[audio_object.id],
-        common_parameter_rate_, *mix_presentation_sub_mix.add_audio_elements());
+        common_parameter_rate_, next_parameter_id_++,
+        *mix_presentation_sub_mix.add_audio_elements());
     if (!status.ok()) {
       return status;
     }
@@ -258,7 +265,7 @@ absl::Status MixPresentationHandler::PopulateMixPresentation(
   auto* param_definition =
       mix_gain_param_definition->mutable_param_definition();
 
-  param_definition->set_parameter_id(0);
+  param_definition->set_parameter_id(next_parameter_id_++);
   param_definition->set_parameter_rate(common_parameter_rate_);
   param_definition->set_param_definition_mode(1);
   mix_gain_param_definition->set_default_mix_gain(0);

--- a/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.h
+++ b/iamf/cli/adm_to_user_metadata/iamf/mix_presentation_handler.h
@@ -83,6 +83,10 @@ class MixPresentationHandler {
  private:
   const uint32_t common_parameter_rate_;
   std::map<std::string, uint32_t> audio_object_id_to_audio_element_id_;
+  // Parameter IDs are unique across the whole IA sequence, not just within a
+  // mix presentation, so this counter is shared by every call to
+  // `PopulateMixPresentation()`.
+  uint32_t next_parameter_id_ = 0;
 };
 
 }  // namespace adm_to_user_metadata

--- a/iamf/cli/adm_to_user_metadata/iamf/tests/mix_presentation_handler_test.cc
+++ b/iamf/cli/adm_to_user_metadata/iamf/tests/mix_presentation_handler_test.cc
@@ -346,10 +346,11 @@ std::vector<uint32_t> CollectMixGainParameterIds(
   return parameter_ids;
 }
 
-void ExpectParameterIdsAreDistinct(const std::vector<uint32_t>& parameter_ids) {
+// Returns true if no two of `parameter_ids` are equal.
+bool AreParameterIdsDistinct(const std::vector<uint32_t>& parameter_ids) {
   const std::set<uint32_t> unique_parameter_ids(parameter_ids.begin(),
                                                 parameter_ids.end());
-  EXPECT_EQ(unique_parameter_ids.size(), parameter_ids.size());
+  return unique_parameter_ids.size() == parameter_ids.size();
 }
 
 TEST(PopulateMixPresentation, AssignsADistinctParameterIdToEachMixGain) {
@@ -362,7 +363,8 @@ TEST(PopulateMixPresentation, AssignsADistinctParameterIdToEachMixGain) {
   const auto parameter_ids =
       CollectMixGainParameterIds(mix_presentation_metadata);
   ASSERT_EQ(parameter_ids.size(), 3);
-  ExpectParameterIdsAreDistinct(parameter_ids);
+  EXPECT_TRUE(AreParameterIdsDistinct(parameter_ids))
+      << "parameter IDs: " << ::testing::PrintToString(parameter_ids);
 }
 
 TEST(PopulateMixPresentation,
@@ -399,7 +401,8 @@ TEST(PopulateMixPresentation,
                        second_parameter_ids.end());
 
   ASSERT_EQ(parameter_ids.size(), 6);
-  ExpectParameterIdsAreDistinct(parameter_ids);
+  EXPECT_TRUE(AreParameterIdsDistinct(parameter_ids))
+      << "parameter IDs: " << ::testing::PrintToString(parameter_ids);
 }
 
 TEST(PopulateMixPresentation, SetsTheCommonParameterRateOnEveryMixGain) {

--- a/iamf/cli/adm_to_user_metadata/iamf/tests/mix_presentation_handler_test.cc
+++ b/iamf/cli/adm_to_user_metadata/iamf/tests/mix_presentation_handler_test.cc
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -325,6 +326,94 @@ TEST(PopulateMixPresentation, PopulatesOneAudioElementPerAudioObject) {
           .sub_mixes(0)
           .audio_elements_size(),
       2);
+}
+
+// Collects every mix gain parameter ID in a populated mix presentation: one
+// per audio element (`element_mix_gain`), plus the sub-mix's
+// `output_mix_gain`.
+std::vector<uint32_t> CollectMixGainParameterIds(
+    const iamf_tools_cli_proto::MixPresentationObuMetadata&
+        mix_presentation_metadata) {
+  std::vector<uint32_t> parameter_ids;
+  for (const auto& sub_mix : mix_presentation_metadata.sub_mixes()) {
+    for (const auto& audio_element : sub_mix.audio_elements()) {
+      parameter_ids.push_back(
+          audio_element.element_mix_gain().param_definition().parameter_id());
+    }
+    parameter_ids.push_back(
+        sub_mix.output_mix_gain().param_definition().parameter_id());
+  }
+  return parameter_ids;
+}
+
+void ExpectParameterIdsAreDistinct(const std::vector<uint32_t>& parameter_ids) {
+  const std::set<uint32_t> unique_parameter_ids(parameter_ids.begin(),
+                                                parameter_ids.end());
+  EXPECT_EQ(unique_parameter_ids.size(), parameter_ids.size());
+}
+
+TEST(PopulateMixPresentation, AssignsADistinctParameterIdToEachMixGain) {
+  // Each `element_mix_gain` carries its own `default_mix_gain`, so sharing an
+  // ID between two of them, or with the sub-mix's `output_mix_gain`, would
+  // describe one parameter with conflicting definitions.
+  const auto& mix_presentation_metadata =
+      GetMixObuMetataExpectOk({GetStereoAudioObject(), Get5_1AudioObject()});
+
+  const auto parameter_ids =
+      CollectMixGainParameterIds(mix_presentation_metadata);
+  ASSERT_EQ(parameter_ids.size(), 3);
+  ExpectParameterIdsAreDistinct(parameter_ids);
+}
+
+TEST(PopulateMixPresentation,
+     AssignsDistinctParameterIdsAcrossMixPresentations) {
+  const std::vector<AudioObject> kAudioObjects = {GetStereoAudioObject(),
+                                                  Get5_1AudioObject()};
+  std::map<std::string, uint32_t> audio_object_id_to_audio_element_id;
+  uint32_t audio_element_id = 0;
+  for (const auto& audio_object : kAudioObjects) {
+    audio_object_id_to_audio_element_id[audio_object.id] = audio_element_id++;
+  }
+  MixPresentationHandler handler(kCommonParameterRate,
+                                 audio_object_id_to_audio_element_id);
+
+  // Parameter IDs are unique across the whole IA sequence, not just within one
+  // mix presentation, so a second mix presentation from the same handler must
+  // not reuse the first one's IDs.
+  iamf_tools_cli_proto::MixPresentationObuMetadata first_mix_presentation;
+  ASSERT_THAT(handler.PopulateMixPresentation(kMixPresentationId, "", "",
+                                              kAudioObjects, LoudnessMetadata(),
+                                              first_mix_presentation),
+              IsOk());
+  iamf_tools_cli_proto::MixPresentationObuMetadata second_mix_presentation;
+  ASSERT_THAT(handler.PopulateMixPresentation(kMixPresentationId + 1, "", "",
+                                              kAudioObjects, LoudnessMetadata(),
+                                              second_mix_presentation),
+              IsOk());
+
+  std::vector<uint32_t> parameter_ids =
+      CollectMixGainParameterIds(first_mix_presentation);
+  const auto second_parameter_ids =
+      CollectMixGainParameterIds(second_mix_presentation);
+  parameter_ids.insert(parameter_ids.end(), second_parameter_ids.begin(),
+                       second_parameter_ids.end());
+
+  ASSERT_EQ(parameter_ids.size(), 6);
+  ExpectParameterIdsAreDistinct(parameter_ids);
+}
+
+TEST(PopulateMixPresentation, SetsTheCommonParameterRateOnEveryMixGain) {
+  const auto& mix_presentation_metadata =
+      GetMixObuMetataExpectOk({GetStereoAudioObject(), Get5_1AudioObject()});
+
+  const auto& sub_mix = mix_presentation_metadata.sub_mixes(0);
+  for (const auto& audio_element : sub_mix.audio_elements()) {
+    EXPECT_EQ(
+        audio_element.element_mix_gain().param_definition().parameter_rate(),
+        kCommonParameterRate);
+  }
+  EXPECT_EQ(sub_mix.output_mix_gain().param_definition().parameter_rate(),
+            kCommonParameterRate);
 }
 
 }  // namespace


### PR DESCRIPTION
`SubMixAudioElementMetadataBuilder` and `PopulateMixPresentation` both
hardcode `parameter_id = 0`, so a sub-mix's `output_mix_gain` and every
audio element's `element_mix_gain` claim the same parameter. The two
definitions are otherwise identical, so the collision is invisible while
every `default_mix_gain` is 0.

An audioObject carrying an authored `<gain>` breaks that tie:
`element_mix_gain.default_mix_gain` becomes non-zero while
`output_mix_gain.default_mix_gain` stays 0, and
`CollectAndValidateParamDefinitions` rejects the sequence with
"Inequivalent `param_definition` for id = 0". The equivalence check is
correct -- one parameter ID cannot have two definitions -- and it also
guards the decode path, so the defect is entirely in the producer.

Allocate IDs from a counter owned by the handler, since parameter IDs are
unique across the IA sequence rather than within one mix presentation.

For an ADM with no authored gains this changes one byte of the output: the
sub-mix `output_mix_gain` parameter ID, 0 to 1.

Fixes #69.
Closes #69

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.