### PR TITLE
Document --adm_importance_threshold as a metadata-only filter

### DIFF
--- a/docs/iamf_encoder_main.md
+++ b/docs/iamf_encoder_main.md
@@ -50,7 +50,9 @@ Flags for ADM-BWF input:
 -   `--adm_filename` Required path to input ADM-BWF WAV file.
 -   `--output_iamf_directory` Directory to write IAMF files to (default: `.`).
 -   `--adm_importance_threshold` Threshold below which ADM `audioObject`s are
-    omitted (default: 0).
+    omitted from the generated IAMF metadata (default: 0). The audio of an
+    omitted object is still rendered into the output; the threshold does not
+    remove channels from the rendered wav file(s).
 -   `--adm_frame_duration_ms` Frame size of the output IAMF in milliseconds
     (default: 10).
 

--- a/iamf/cli/adm_to_user_metadata/README.md
+++ b/iamf/cli/adm_to_user_metadata/README.md
@@ -66,7 +66,7 @@ The input format required to run the binary is as below:
 
 options:
   --adm_filename (required) - ADM wav file to process.
-  --importance_threshold (optional) - Used to reject objects whose importance is below the given threshold of range 0 to 10 (default 0).
+  --importance_threshold (optional) - Omits objects whose importance is below the given threshold of range 0 to 10 from the generated metadata (default 0). The audio of an omitted object is still rendered into the output.
   --frame_duration_ms (optional) - Target frame duration in ms. The actual output may be slightly lower due to rounding. (default 10).
   --write_binary_proto (optional) - Whether to write the output as a binary proto or a textproto (default true)
   --output_file_path (optional) - Path to write output files to. (default current directory)
@@ -94,8 +94,11 @@ options:
     -   Some types directly representable in IAMF include {stereo, 5.1, 7.1.4,
         third_order_ambisonics}. One type that is not representable directly in
         IAMF includes objects.
-    -   Low importance objects are filtered out based on the
-        `--importance_threshold` flag.
+    -   Low importance objects are filtered out of the generated metadata
+        based on the `--importance_threshold` flag. This is a metadata-only
+        filter: the wav splicer and the panner address the input file's
+        channels by position, so a filtered object's audio is still rendered
+        into the output.
 -   Mix Presentation OBUs: mix presentations are generated based on ADM
     `audioProgramme`s.
 

--- a/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/xml_to_adm.cc
@@ -326,9 +326,30 @@ absl::Status SetAudioBlockValue(absl::string_view key, absl::string_view value,
 // Removes objects from the ADM structure based on the given importance
 // threshold. Also, removes audio objects with IDs found in the set of invalid
 // audio objects.
+//
+// The importance threshold affects the ADM structure, and through it the
+// generated IAMF metadata, only. It does not affect the rendered audio: the
+// wav splicer and the panner address the input file's channels by position
+// and carry no importance term, so a dropped object's samples are still
+// spliced and still panned into the output.
 void RemoveLowImportanceAndInvalidAudioObjects(int32_t importance_threshold,
                                                Handler& handler) {
   std::vector<AudioObject>& audio_object_list = handler.adm.audio_objects;
+  int num_removed_for_importance = 0;
+  for (const auto& audio_object : audio_object_list) {
+    if (audio_object.importance < importance_threshold &&
+        !handler.invalid_audio_objects.contains(audio_object.id)) {
+      ++num_removed_for_importance;
+    }
+  }
+  if (num_removed_for_importance > 0) {
+    ABSL_LOG(WARNING)
+        << "Removed " << num_removed_for_importance
+        << " audioObject(s) with an importance below " << importance_threshold
+        << " from the ADM metadata. Their audio is still rendered into the "
+           "output; the importance threshold does not remove channels from "
+           "the rendered wav file(s).";
+  }
   audio_object_list.erase(
       std::remove_if(audio_object_list.begin(), audio_object_list.end(),
                      [&](AudioObject value) {

--- a/iamf/cli/encoder_main.cc
+++ b/iamf/cli/encoder_main.cc
@@ -50,8 +50,11 @@ ABSL_FLAG(std::string, adm_profile_version, "base",
           "IAMF version to be used: (base/enhanced). Used only if "
           "--adm_filename is provided.");
 ABSL_FLAG(int32_t, adm_importance_threshold, 0,
-          "Importance value used to skip an audioObject. Clamped to [0, 10]. "
-          "Used only if --adm_filename is provided.");
+          "Importance value below which an audioObject is omitted from the "
+          "generated IAMF metadata. Clamped to [0, 10]. This does not remove "
+          "the object's audio: every channel of the input file is still "
+          "rendered into the output. Used only if --adm_filename is "
+          "provided.");
 ABSL_FLAG(int32_t, adm_frame_duration_ms, 10,
           "Target frame duration in milliseconds. The actual frame duration "
           "may vary slightly. Used only if --adm_filename is provided.");


### PR DESCRIPTION
`RemoveLowImportanceAndInvalidAudioObjects` erases entries from
`ADM::audio_objects`. The rendering path does not read that list:
`wav_file_splicer` sizes its work from the wav's channel count and
`PanObjectsToAmbisonics` iterates `ADM::audio_channels` by position, with no
importance term anywhere between them. Encoding an eight-object ADM at
threshold 0 and at threshold 11 therefore produces byte-identical output --
the objects the user asked to drop are still in the render at full level.

Making the threshold prune the render is a much larger change: for
Dolby-mode input every object is a source in one shared ambisonic scene, so
removing one changes the downmix for the objects that remain. Until that is
decided, say what the flag does. The flag help, the encoder docs and the
`adm_to_user_metadata` README now scope it to the generated metadata, and a
warning naming the discrepancy is logged when the threshold actually drops
an object, so a user who sets it does not have to diff two bitstreams to
find out it did nothing to the audio.

Bug: #70
Refs #70

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.