### PR TITLE
adm_to_user_metadata: do not emit a bitstream that describes no audio

### DIFF
--- a/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
+++ b/iamf/cli/adm_to_user_metadata/adm/wav_file_splicer.cc
@@ -597,13 +597,18 @@ absl::Status SeparateLfeChannels(const std::filesystem::path& output_file_path,
   size_t num_samples_to_read = kSizeToFlush;
   std::vector<char> temp_buffer(num_samples_to_read * bytes_per_sample *
                                 num_channels);
+  // The buffer is reused for every chunk; its logical size is the chunk size
+  // and must stay constant for the lifetime of the loop below. Bind it once
+  // rather than querying the vector, so that the read size, the loop stride
+  // and the buffer's extent cannot drift apart.
+  const size_t bytes_per_read = temp_buffer.size();
 
   // Perform the file read in chunks and use the temporary buffer for further
   // processing.
   for (size_t data_chunk_pos = 0; data_chunk_pos < data_chunk_info.size;
-       data_chunk_pos += temp_buffer.capacity()) {
+       data_chunk_pos += bytes_per_read) {
     const size_t bytes_to_read =
-        std::min(temp_buffer.capacity(), data_chunk_info.size - data_chunk_pos);
+        std::min(bytes_per_read, data_chunk_info.size - data_chunk_pos);
     if (!input_stream.read(temp_buffer.data(), bytes_to_read)) {
       AbortAllWavWriters(nonlfe_lfe_wav_writer);
       return absl::OutOfRangeError(
@@ -614,7 +619,6 @@ absl::Status SeparateLfeChannels(const std::filesystem::path& output_file_path,
     RETURN_IF_NOT_OK(FlushLfeNonLfeWavs(
         temp_buffer, bytes_to_read, num_channels, bytes_per_sample,
         *segment_layout, nonlfe_lfe_wav_writer));
-    temp_buffer.clear();
   }
   return absl::OkStatus();
 }

--- a/iamf/cli/adm_to_user_metadata/app/BUILD
+++ b/iamf/cli/adm_to_user_metadata/app/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "//iamf/obu:ia_sequence_header",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:string_view",
     ],
 )

--- a/iamf/cli/adm_to_user_metadata/app/adm_to_user_metadata_main_lib.cc
+++ b/iamf/cli/adm_to_user_metadata/app/adm_to_user_metadata_main_lib.cc
@@ -11,12 +11,14 @@
  */
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <istream>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "iamf/cli/adm_to_user_metadata/adm/adm_elements.h"
 #include "iamf/cli/adm_to_user_metadata/adm/bw64_reader.h"
@@ -37,31 +39,58 @@ constexpr char kAudioPackFormatIdFor3OA[] = "AP_00040003";
 // DirectSpeakers (0001) and layout as LFE (1FFF).
 constexpr char kAudioPackFormatIdForLfe[] = "AP_00011FFF";
 
-void ModifyAdmToPanObjectsTo3OAAndSeparateLfe(
+absl::Status ModifyAdmToPanObjectsTo3OAAndSeparateLfe(
     const ProfileVersion profile_version, const int lfe_count,
     ADM& adm_metadata) {
   using enum ProfileVersion;
+  auto& audio_objects = adm_metadata.audio_objects;
+
+  // `ParseXmlToAdm` drops audioObjects it cannot validate and returns OK, so
+  // this list can be empty on a file that parsed successfully. Both branches
+  // below index element 0 and rewrite its first `audioPackFormatIDRef`.
+  if (audio_objects.empty()) {
+    return absl::NotFoundError("No audioObject present.");
+  }
+  if (audio_objects[0].audio_pack_format_id_refs.empty()) {
+    return absl::InvalidArgumentError(
+        "The first audioObject has no `audioPackFormatIDRef`.");
+  }
+
   if (profile_version == kIamfBaseProfile) {
     // For IA Base Profile, max channels allowed per mix is 18, hence pan all
     // audio objects(both channel beds and objects) to 3OA (16 channels).
-    adm_metadata.audio_objects.erase(adm_metadata.audio_objects.begin() + 1,
-                                     adm_metadata.audio_objects.end());
-    adm_metadata.audio_objects[0].audio_pack_format_id_refs[0] =
-        kAudioPackFormatIdFor3OA;
+    audio_objects.resize(1);
+    audio_objects[0].audio_pack_format_id_refs[0] = kAudioPackFormatIdFor3OA;
   } else if (profile_version == kIamfBaseEnhancedProfile) {
     // For IA Base Enhanced Profile, max channels allowed per mix is 28, hence
     // pan all non-LFE channels(both channel beds and objects) in the to 3OA (16
-    // channels) and keep the LFE(s) as separate audio element(s).
-    adm_metadata.audio_objects.erase(
-        adm_metadata.audio_objects.begin() + 1 + lfe_count,
-        adm_metadata.audio_objects.end());
-    adm_metadata.audio_objects[0].audio_pack_format_id_refs[0] =
-        kAudioPackFormatIdFor3OA;
+    // channels) and keep the LFE(s) as separate audio element(s). This needs
+    // one audioObject for the ambisonics element and one per LFE channel.
+    if (lfe_count < 0) {
+      return absl::InvalidArgumentError(
+          "LFE channel count must not be negative.");
+    }
+    const size_t num_required_audio_objects =
+        1 + static_cast<size_t>(lfe_count);
+    if (audio_objects.size() < num_required_audio_objects) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "IA Base Enhanced Profile needs one audioObject for the ambisonics "
+          "element and one per LFE channel; the ADM has ",
+          audio_objects.size(), " audioObject(s) for ", lfe_count,
+          " LFE channel(s)."));
+    }
+    audio_objects.resize(num_required_audio_objects);
+    audio_objects[0].audio_pack_format_id_refs[0] = kAudioPackFormatIdFor3OA;
     for (int lfe_index = 1; lfe_index <= lfe_count; ++lfe_index) {
-      adm_metadata.audio_objects[lfe_index].audio_pack_format_id_refs[0] =
+      if (audio_objects[lfe_index].audio_pack_format_id_refs.empty()) {
+        return absl::InvalidArgumentError(
+            "An audioObject has no `audioPackFormatIDRef`.");
+      }
+      audio_objects[lfe_index].audio_pack_format_id_refs[0] =
           kAudioPackFormatIdForLfe;
     }
   }
+  return absl::OkStatus();
 }
 
 }  // namespace
@@ -88,8 +117,8 @@ GenerateUserMetadataAndSpliceWavFiles(
   ADM adm_metadata = reader->adm_;
 
   if (reader->adm_.file_type == kAdmFileTypeDolby) {
-    ModifyAdmToPanObjectsTo3OAAndSeparateLfe(profile_version, lfe_count,
-                                             adm_metadata);
+    RETURN_IF_NOT_OK(ModifyAdmToPanObjectsTo3OAAndSeparateLfe(
+        profile_version, lfe_count, adm_metadata));
   }
 
   // Generate the user metadata.

--- a/iamf/cli/adm_to_user_metadata/iamf/user_metadata_generator.cc
+++ b/iamf/cli/adm_to_user_metadata/iamf/user_metadata_generator.cc
@@ -190,6 +190,18 @@ UserMetadataGenerator::GenerateUserMetadata(
     }
   }
 
+  // An audioProgramme with more audio object groups than an IAMF mix can hold
+  // is skipped rather than rejected, so it is possible to arrive here having
+  // described no audio at all. Encoding that metadata produces a descriptor-
+  // only bitstream that carries nothing and that this project's own tools
+  // cannot parse, so say so instead.
+  if (user_metadata.audio_element_metadata().empty() ||
+      user_metadata.audio_frame_metadata().empty()) {
+    return absl::InvalidArgumentError(
+        "No audio element could be generated from this ADM. Every "
+        "audioProgramme was either empty or larger than an IAMF mix allows.");
+  }
+
   return user_metadata;
 }
 


### PR DESCRIPTION
An audioProgramme with more audio object groups than `kMaxAudioElementPerMix`
is skipped with a message on stdout, and the generator carries on. If that was
the only programme, the user metadata ends up with no audio elements and no
audio frames, and `encoder_main` writes a 25-byte descriptor-only file, exits
0, and reports success -- a file this project's own `probe_main` rejects with
"Insufficient data to parse descriptor OBUs".

The cap itself is worth revisiting separately: it is 2 for every profile,
while IA Base Enhanced allows 28 audio elements per mix, so a Dolby ADM with
two LFE channels is over the limit purely because the limit is not
profile-aware. Whatever that number becomes, silently succeeding with nothing
in the bitstream is the wrong outcome, so refuse instead.

Measured on a Dolby ADM with two LFE channels under
`--adm_profile_version=enhanced`: a 25-byte file and `rc 0` become a stated
error. Twelve corpus encodes across both profiles are byte-identical.
Closes #91

Tested with `bazel test //...` on macOS arm64 (Bazel 8.5.1, clang 17):
152 passing, 0 failing, 5 fuzz targets skipped, 3741 test cases.